### PR TITLE
L21Norm first implementation

### DIFF
--- a/doc/api/functionals/pycsou.func.penalty.rst
+++ b/doc/api/functionals/pycsou.func.penalty.rst
@@ -20,6 +20,7 @@ Penalty Functionals
       L2Norm
       SquaredL2Norm
       LInftyNorm
+      L21Norm
 
    .. rubric:: Balls
 

--- a/pycsou/func/loss.py
+++ b/pycsou/func/loss.py
@@ -1,7 +1,7 @@
 # #############################################################################
 # loss.py
 # ==========
-# Author : Matthieu Simeoni [matthieu.simeoni@gmail.com]
+# Authors : Matthieu Simeoni [matthieu.simeoni@gmail.com]
 # #############################################################################
 
 r"""

--- a/pycsou/func/penalty.py
+++ b/pycsou/func/penalty.py
@@ -489,7 +489,7 @@ class L21Norm(ProximableFunctional):
 
     .. doctest::
 
-       >>> x = np.arange(10)
+       >>> x = np.arange(10,dtype=np.float64)
        >>> groups = np.concatenate((np.ones(5),2*np.ones(5)))
        >>> group_norm = L21Norm(dim=x.size,groups=groups)
        >>> type(group_norm)
@@ -502,9 +502,7 @@ class L21Norm(ProximableFunctional):
        >>> l1_norm = L21Norm(dim=x.size,groups=np.arange(x.size)) # Also if groups = None
        <class 'pycsou.func.penalty.L1Norm'>
        >>> single_group_l2 = L2Norm(dim=x.size/2)
-       >>> tau = 0.5; np.allclose(group_norm.prox(x,tau=tau),
-                                  np.concatenate((single_group_l2.prox(x[0:5], tau=tau),
-                                                  single_group_l2.prox(x[5:10],tau=tau))))
+       >>> tau = 0.5; np.allclose(group_norm.prox(x,tau=tau),np.concatenate((single_group_l2.prox(x[0:5], tau=tau),single_group_l2.prox(x[5:10],tau=tau))))
        True
 
     Notes

--- a/pycsou/func/penalty.py
+++ b/pycsou/func/penalty.py
@@ -2,7 +2,7 @@
 # penalty.py
 # ==========
 # Author : Matthieu Simeoni [matthieu.simeoni@gmail.com]
-# Contributors: Pol del Aguila Pla [poldap@gmail.com] - L21Norm class
+# Contributors: Pol del Aguila Pla [polsocjo@gmail.com] - L21Norm class
 # #############################################################################
 
 r"""
@@ -512,7 +512,7 @@ class L21Norm(ProximableFunctional):
     The :math:`\ell_{2,1}`-norm penalty is convex and proximable. This penalty tends to produce group sparse solutions,
     where all elements :math:`x_i` for :math:`i\in\mathcal{G}_g` for some :math:`g\in\lbrace 1,2,\dots,G` tend to
     be zero or non-zero jointly. A critical assumtion is that the groups are not overlapping, i.e.,
-    :math:`\mathcal{G}_j \cap \mathcal{G}_i = \emptyset\mbox{ for }j,i \in \lbrace 1,2,\dots,G\mbox{ such that }j\neq i.`
+    :math:`\mathcal{G}_j \cap \mathcal{G}_i = \emptyset` for :math:`j,i \in \lbrace 1,2,\dots,G\rbrace` such that :math:`j\neq i.`
     The proximal operator of the :math:`\ell_{2,1}`-norm is obtained easily from that of the :math:`\ell_2`-norm and the
     separable sum property.
 


### PR DESCRIPTION
An initial implementation of the L21Norm class as a penalty. It does not yet use the ProximalHStack concept, but its main structure can be deployed awaiting this improvement. 