### PR TITLE
Add diagnostic updates for iterates.

### DIFF
--- a/pycsou/core/solver.py
+++ b/pycsou/core/solver.py
@@ -85,7 +85,7 @@ class GenericIterativeAlgorithm(ABC):
         self.iter = 0
         self.iterand = None
 
-    def iterates(self, n: int) -> Tuple:
+    def iterates(self, n: int, update_diagnostics=False) -> Tuple:
         r"""
         Generator allowing to loop through the n first iterates.
 
@@ -95,11 +95,19 @@ class GenericIterativeAlgorithm(ABC):
         ----------
         n: int
             Max number of iterates to loop through.
+        update_diagnostics : bool
+            Whether to update diagnostics at each iteration.
         """
+        if update_diagnostics:
+            self.old_iterand = deepcopy(self.init_iterand)
+            self.update_diagnostics()   # to build diagnostics dict
         self.reset()
         for i in range(n):
             self.iterand = self.update_iterand()
             self.iter += 1
+            if update_diagnostics:
+                self.update_diagnostics()
+                self.old_iterand = deepcopy(self.iterand)
             yield self.iterand
 
     @abstractmethod


### PR DESCRIPTION
I find the `iterates` method useful for plotting / debugging intermediate reconstructions. But the diagnostics are not updated in between iterations. One option I've hacked together is to add a `update_diagnostics` flag when calling `iterates` so that the user doesn't have to do something like below:

```python
apgd = APDG(...)
apgd.old_iterand = deepcopy(apgd.init_iterand)
apgd.update_diagnostics()
gen = apgd.iterates(n=max_iter)

for i, iter in enumerate (gen):
    if (i + 1) % disp == 0:
        apgd.update_diagnostics()
        apgd.old_iterand = deepcopy(apgd.iterand)
        apgd.print_diagnostics()
```

but rather
```python
apgd = APDG(...)
gen = apgd.iterates(n=max_iter, update_diagnostics=True)

for i, iter in enumerate (gen):
    if (i + 1) % disp == 0:
        apgd.print_diagnostics()
```

However, I wonder if it's better to initialize `self.old_iterand` and create the `self.diagnostics` dictionary (calling `self.update_diagnostics()`) directly in the constructor? To also avoid creating the class member `self.old_iterand` in  `iterate`.