### PR TITLE
[v2_lsqmr] Implement LSQR and LSMR solvers and their customized Stopping Criterion. 

### DIFF
--- a/doc/pycsou.opt.solver.rst
+++ b/doc/pycsou.opt.solver.rst
@@ -20,6 +20,22 @@ pycsou.opt.solver.cg module
    :undoc-members:
    :show-inheritance:
 
+pycsou.opt.solver.lsqr module
+---------------------------
+
+.. automodule:: pycsou.opt.solver.lsqr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pycsou.opt.solver.lsmr module
+---------------------------
+
+.. automodule:: pycsou.opt.solver.lsmr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/src/pycsou/opt/solver/lsmr.py
+++ b/src/pycsou/opt/solver/lsmr.py
@@ -1,0 +1,307 @@
+import typing as typ
+
+import numpy as np
+
+import pycsou.abc.operator as pyco
+import pycsou.abc.solver as pycs
+import pycsou.opt.stop as pycos
+import pycsou.runtime as pycrt
+import pycsou.util as pycu
+import pycsou.util.ptype as pyct
+
+
+class LSMR(pycs.Solver):
+    r"""
+     LSMR Method.
+
+     The LSMR method solves the system of linear equations :math:`\mathbf{A}\mathbf{x}=\mathbf{b}` iteratively. If the
+     system is inconsistent, it solves the least-squares problem :math:`\min ||\mathbf{b} - \mathbf{A}\mathbf{x}||_2`.
+     :math:`\mathbf{A}` is a rectangular matrix of dimension m-by-n, where all cases are allowed: m=n, m>n or m<n.
+     :math:`\mathbf{b}` is a vector of length m. The matrix :math:`\mathbf{A}` may be dense or sparse.
+
+     ``CG()`` **Parameterization**
+     A: pycsou.abc.operator.PosDefOp
+        Any positive definite linear operator is accepted.
+     damp: float
+        Damping coefficient. Default is 0.
+     atol, btol: float
+        Stopping tolerances. LSMR continues iterations until a certain backward error estimate is smaller than some
+        quantity depending on atol and btol. Default is 1e-6 for both.
+     conlim: float
+        LSMR terminates if an estimate :math:`cond(\mathbf{A})` exceeds conlim. Default is 1e8.
+     iter_lim: int, optional
+        LSMR terminates if the number of iterations reaches iter_lim. Default is None.
+
+     ``CG.fit()`` **Parameterization**
+
+     b: NDArray
+         (..., N) 'b' terms in the LSMR cost function. All problems are solved in parallel.
+     x0: NDArray
+        (..., N) initial point(s). Defaults to 0 if unspecified.
+     restart_rate: int
+        Number of iterations after which restart is applied. By default, restart is done after 'n' iterations, where 'n'
+        corresponds to the dimension of the linear operator :math:`\mathbf{A}`.
+
+    **Remark:** In pycsou.opt.solver.stop, StopCriterion_LSMR is developed for the stopping criterion of LSMR. For
+    computational speed, explicit norms were not computated. Instead, their estimation was used, which is referred from
+    [1].
+
+     References
+     ----------
+        [1] D. C.-L. Fong and M. A. Saunders,
+            "LSMR: An iterative algorithm for sparse least-squares problems",
+            SIAM J. Sci. Comput., vol. 33, pp. 2950-2971, 2011.
+     Examples
+     --------
+     >>> import numpy as np
+     >>> from pycsou.abc import LinOp
+     >>> # Create a PSD linear operator
+     >>> rng = np.random.default_rng(seed=0)
+     >>> mat = rng.normal(size=(10, 10))
+     >>> A = LinOp.from_array(mat).gram()
+     >>> # Create the ground truth 'x_star'
+     >>> x_star = rng.normal(size=(2, 2, 10))
+     >>> # Generate the corresponding data vector 'b'
+     >>> b = A.apply(x_star)
+     >>> # Solve 'Ax=b' for 'x' with the conjugate gradient method
+     >>> lsmr = LSMR(A, show_progress=False)
+     >>> lsmr.fit(b=b)
+     >>> x_solution = lsmr.solution()
+     >>> assert np.allclose(x_star, x_solution)
+    """
+
+    def __init__(
+        self,
+        A: pyco.PosDefOp,
+        *,
+        damp: float = 0.0,
+        atol: float = 1e-06,
+        btol: float = 1e-06,
+        conlim: float = 1e08,
+        iter_lim: typ.Optional[int] = None,
+        folder: typ.Optional[pyct.PathLike] = None,
+        exist_ok: bool = False,
+        writeback_rate: typ.Optional[int] = None,
+        verbosity: int = 1,
+        show_progress: bool = True,
+        log_var: pyct.VarName = ("x",),
+    ):
+        super().__init__(
+            folder=folder,
+            exist_ok=exist_ok,
+            writeback_rate=writeback_rate,
+            verbosity=verbosity,
+            show_progress=show_progress,
+            log_var=log_var,
+        )
+
+        self._A = A
+        self._atol = atol
+        self._btol = btol
+        self._ctol = (1.0 / conlim) if (conlim > 0) else 0.0
+        self._iter_lim = (min(A.shape[0], A.shape[1])) if (iter_lim is None) else iter_lim
+        self._damp = damp
+        self._itn = 0
+        self._normb = None
+
+    @pycrt.enforce_precision(i=["b", "x0"], allow_None=True)
+    def m_init(
+        self,
+        b: pyct.NDArray,
+        x0: typ.Optional[pyct.NDArray] = None,
+    ):
+        xp = pycu.get_array_module(b)
+
+        u = b
+        normb = xp.linalg.norm(b)
+
+        if x0 is None:
+            # TODO: make sure shape is correct
+            x = xp.zeros((self._A.shape[1],))
+            beta = normb.copy()
+        else:
+            x = x0.copy()
+            u -= self._A.apply(x)
+            beta = xp.linalg.norm(u)
+
+        # TODO: If b is 0-vector, make x 0-vector!
+
+        if beta > 0:
+            u *= 1 / beta
+            v = self._A.T.apply(u)
+            alpha = xp.linalg.norm(v)
+        else:
+            v = xp.zeros_like(x)
+            alpha = 0
+
+        if alpha > 0:
+            v *= 1 / alpha
+
+        mst = self._mstate
+        mst["x"], mst["u"], mst["v"], mst["alpha"] = x, u, v, alpha
+
+        # Initialize variables for 1st iteration:
+        mst["zetabar"], mst["alphabar"] = alpha * beta, alpha
+        mst["rho"] = mst["rhobar"] = mst["cbar"] = 1
+        mst["sbar"] = 0
+        mst["h"], mst["hbar"] = v.copy(), xp.zeros_like(x)
+
+        # Initialize variables for estimation of ||r||:
+        mst["betadd"] = beta
+        mst["rhodold"] = 1
+        mst["betad"] = mst["tautildeold"] = mst["thetatilde"] = mst["zeta"] = mst["d"] = 0
+
+        # Initialize variables for estimation of ||A|| and cond(A):
+        mst["normA2"] = alpha**2
+        mst["maxrbar"], mst["minrbar"] = 0, 1e100
+        mst["normA"], mst["condA"] = xp.sqrt(mst["normA2"]), 1
+        mst["normx"], mst["normr"], mst["normar"] = 0, beta, alpha * beta
+        self._normb = normb
+
+        # Initialize variables for testing stopping rules:
+        mst["test1"], mst["test2"], mst["test3"] = 1, alpha / beta, None
+
+    @staticmethod
+    def _sym_ortho(a, b, xp):
+        """
+        Stable implementation of Givens rotation.
+        """
+        if b == 0:
+            return xp.sign(a), 0, xp.abs(a)
+        elif a == 0:
+            return 0, xp.sign(b), xp.abs(b)
+        elif xp.abs(b) > xp.abs(a):
+            tau = a / b
+            s = xp.sign(b) / xp.sqrt(1 + tau**2)
+            c = s * tau
+            r = b / s
+        else:
+            tau = b / a
+            c = xp.sign(a) / xp.sqrt(1 + tau**2)
+            s = c * tau
+            r = a / c
+        return c, s, r
+
+    def m_step(self):
+        self._itn += 1
+
+        mst = self._mstate
+        xp = pycu.get_array_module(mst["x"])
+
+        x, u, v, alpha = mst["x"], mst["u"], mst["v"], mst["alpha"]
+        zetabar, alphabar = mst["zetabar"], mst["alphabar"]
+        rho, rhobar, cbar = mst["rho"], mst["rhobar"], mst["cbar"]
+        sbar, h, hbar = mst["sbar"], mst["h"], mst["hbar"]
+        betadd, betad, tautildeold, thetatilde = mst["betadd"], mst["betad"], mst["tautildeold"], mst["thetatilde"]
+        rhodold, zeta, d = mst["rhodold"], mst["zeta"], mst["d"]
+        normA2, minrbar, maxrbar = mst["normA2"], mst["minrbar"], mst["maxrbar"]
+
+        # Bidiagonalizaion to obtain next beta, u, alpha, v:
+        u = self._A.apply(v) - alpha * u
+        beta = xp.linalg.norm(u)
+
+        if beta > 0:
+            u *= 1 / beta
+            v = self._A.T.apply(u) - beta * v
+            alpha = xp.linalg.norm(v)
+            if alpha > 0:
+                v *= 1 / alpha
+
+        # Construct rotation:
+        chat, shat, alphahat = self._sym_ortho(alphabar, self._damp, xp)
+
+        # Use a plane rotation to turn B_i to R_i:
+        rhoold = rho
+        c, s, rho = self._sym_ortho(alphahat, beta, xp)
+        thetanew = s * alpha
+        alphabar = c * alpha
+
+        # Use a plane rotation to turn R_i^T to R_i^bar:
+        rhobarold = rhobar
+        zetaold = zeta
+        thetabar = sbar * rho
+        rhotemp = cbar * rho
+        cbar, sbar, rhobar = self._sym_ortho(cbar * rho, thetanew, xp)
+        zeta = cbar * zetabar
+        zetabar = -sbar * zetabar
+
+        # Update h, h_hat, x:
+        hbar = h - hbar * (thetabar * rho / (rhoold * rhobarold))
+        x += (zeta / (rho * rhobar)) * hbar
+        h = v - h * (thetanew / rho)
+
+        # Estimation of ||r||:
+
+        betaacute = chat * betadd
+        betacheck = -shat * betadd
+
+        betahat = c * betaacute
+        betadd = -s * betaacute
+
+        thetatildeold = thetatilde
+        ctildeold, stildeold, rhotildeold = self._sym_ortho(rhodold, thetabar, xp)
+        thetatilde = stildeold * rhobar
+        rhodold = ctildeold * rhobar
+        betad = -stildeold * betad + ctildeold * betahat
+
+        tautildeold = (zetaold - thetatildeold * tautildeold) / rhotildeold
+        taud = (zeta - thetatilde * tautildeold) / rhodold
+        d += betacheck**2
+        normr = xp.sqrt(d + (betad - taud) ** 2 + betadd**2)
+
+        # Estimation of ||A||:
+        normA2 = normA2 + beta**2
+        normA = xp.sqrt(normA2)
+        normA2 = normA2 + alpha**2
+
+        # Estimation of cond(A):
+        maxrbar = max(maxrbar, rhobarold)
+        if self._itn > 1:
+            minrbar = min(minrbar, rhobarold)
+        condA = max(maxrbar, rhotemp) / min(minrbar, rhotemp)
+
+        # Compute norms for convergence testing:
+        normar = abs(zetabar)
+        normx = xp.linalg.norm(x)
+
+        # Compute testing parameters:
+        test1 = normr / self._normb
+        if (normA * normr) != 0:
+            test2 = normar / (normA * normr)
+        else:
+            test2 = np.infty
+        test3 = 1 / condA
+        t1 = test1 / (1 + normA * normx / self._normb)
+        rtol = self._btol + self._atol * normA * normx / self._normb
+
+        mst["x"], mst["u"], mst["v"], mst["alpha"] = x, u, v, alpha
+        mst["zetabar"], mst["alphabar"] = zetabar, alphabar
+        mst["rho"], mst["rhobar"], mst["cbar"] = rho, rhobar, cbar
+        mst["sbar"], mst["h"], mst["hbar"] = sbar, h, hbar
+        mst["betadd"], mst["betad"] = betadd, betad
+        mst["tautildeold"], mst["thetatilde"] = tautildeold, thetatilde
+        mst["rhodold"], mst["zeta"], mst["d"] = rhodold, zeta, d
+        mst["maxrbar"], mst["minrbar"] = maxrbar, minrbar
+        mst["normA2"], mst["normA"], mst["condA"] = normA2, normA, condA
+        mst["normx"], mst["normr"], mst["normar"] = normx, normr, normar
+        mst["test1"], mst["test2"], mst["test3"] = test1, test2, test3
+        mst["t1"], mst["rtol"] = t1, rtol
+
+    def default_stop_crit(self) -> pycs.StoppingCriterion:
+        stop_crit = pycos.StopCriterion_LSMR(
+            atol=self._atol,
+            ctol=self._ctol,
+            itn=0,
+            iter_lim=self._iter_lim,
+        )
+        return stop_crit
+
+    def solution(self) -> pyct.NDArray:
+        """
+        Returns
+        -------
+        p: NDArray
+            (..., N) solution.
+        """
+        data, _ = self.stats()
+        return data.get("x")

--- a/src/pycsou/opt/solver/lsqr.py
+++ b/src/pycsou/opt/solver/lsqr.py
@@ -1,3 +1,9 @@
+# #############################################################################
+# lsqr.py
+# ========
+# Author : Kaan Okumus [okukaan@gmail.com]
+# #############################################################################
+
 import typing as typ
 
 import numpy as np
@@ -12,67 +18,72 @@ import pycsou.util.ptype as pyct
 
 class LSQR(pycs.Solver):
     r"""
-     LSQR Method.
+    LSQR Method.
 
-     The LSQR method solves the system of linear equations :math:`\mathbf{A}\mathbf{x}=\mathbf{b}` iteratively.
-     :math:`\mathbf{A}` is a rectangular matrix of dimension m-by-n, where all cases are allowed: m=n, m>n or m<n.
-     :math:`\mathbf{b}` is a vector of length m. The matrix :math:`\mathbf{A}` may be square or rectangular and may have
-     any rank.
-     For unsymmetric equations, it solves :math:`\mathbf{A}\mathbf{x}=\mathbf{b}`.
-     For linear least squares, it solves :math:`||\mathbf{b}-\mathbf{A}\mathbf{x}||^2`.
-     For damped least squares, it solves :math:`||\mathbf{b}-\mathbf{A}\mathbf{x}||^2 + d^2 ||\mathbf{x}-\mathbf{x_0}||
-     ^2`.
+    The LSQR method solves the system of linear equations :math:`\mathbf{A}\mathbf{x}=\mathbf{b}` iteratively.
+    :math:`\mathbf{A}` is a rectangular matrix of dimension m-by-n, where all cases are allowed: m=n, m>n or m<n.
+    :math:`\mathbf{b}` is a vector of length m. The matrix :math:`\mathbf{A}` may be square or rectangular and may have
+    any rank.
+
+    * For unsymmetric equations, it solves :math:`\mathbf{A}\mathbf{x}=\mathbf{b}`.
+
+    * For linear least squares, it solves :math:`||\mathbf{b}-\mathbf{A}\mathbf{x}||^2`.
+
+    * For damped least squares, it solves :math:`||\mathbf{b}-\mathbf{A}\mathbf{x}||^2 + d^2 ||\mathbf{x}-\mathbf{x_0}||^2`.
 
 
-     ``CG()`` **Parameterization**
-     A: pycsou.abc.operator.PosDefOp
+    ``LSQR()`` **Parameterization**
+
+    A: :py:class:`pycsou.abc.operator.PosDefOp`
         Any positive definite linear operator is accepted.
-     damp: float
+    damp: float
         Damping coefficient. Default is 0.
-     atol, btol: float
+    atol, btol: float
         Stopping tolerances. LSQR continues iterations until a certain backward error estimate is smaller than some
         quantity depending on atol and btol. Default is 1e-6 for both.
-     conlim: float
-        LSQR terminates if an estimate :math:`cond(\mathbf{A})` exceeds conlim. Default is 1e8.
-     iter_lim: int, optional
+    conlim: float
+        LSQR terminates if an estimate :math:`\text{cond}(\mathbf{A})` exceeds conlim. Default is 1e8.
+    iter_lim: int, optional
         LSQR terminates if the number of iterations reaches iter_lim. Default is None.
 
-     ``CG.fit()`` **Parameterization**
+    ``LSQR.fit()`` **Parameterization**
 
-     b: NDArray
+    b: NDArray
          (..., N) 'b' terms in the LSQR cost function. All problems are solved in parallel.
-     x0: NDArray
+    x0: NDArray
         (..., N) initial point(s). Defaults to 0 if unspecified.
-     restart_rate: int
+    restart_rate: int
         Number of iterations after which restart is applied. By default, restart is done after 'n' iterations, where 'n'
         corresponds to the dimension of the linear operator :math:`\mathbf{A}`.
 
-    **Remark:** In pycsou.opt.solver.stop, StopCriterion_LSQR is developed for the stopping criterion of LSQR. For
+    **Remark:** :py:class:`pycsou.opt.solver.stop.StopCriterion_LSQR` is developed for the stopping criterion of LSQR. For
     computational speed, explicit norms were not computated. Instead, their estimation was used, which is referred from
-    [1].
+    [1]_.
 
-     References
-     ----------
-        [1] S.-C. Choi, "Iterative Methods for Singular Linear Equations
-            and Least-Squares Problems", Dissertation,
-            http://www.stanford.edu/group/SOL/dissertations/sou-cheng-choi-thesis.pdf
-     Examples
-     --------
-     >>> import numpy as np
+    Examples
+    --------
+    >>> import numpy as np
      >>> from pycsou.abc import LinOp
-     >>> # Create a PSD linear operator
-     >>> rng = np.random.default_rng(seed=0)
-     >>> mat = rng.normal(size=(10, 10))
-     >>> A = LinOp.from_array(mat).gram()
-     >>> # Create the ground truth 'x_star'
-     >>> x_star = rng.normal(size=(2, 2, 10))
-     >>> # Generate the corresponding data vector 'b'
-     >>> b = A.apply(x_star)
-     >>> # Solve 'Ax=b' for 'x' with the conjugate gradient method
-     >>> lsqr = LSQR(A, show_progress=False)
-     >>> lsqr.fit(b=b)
-     >>> x_solution = lsqr.solution()
-     >>> assert np.allclose(x_star, x_solution)
+    >>> # Create a PSD linear operator
+    >>> rng = np.random.default_rng(seed=0)
+    >>> mat = rng.normal(size=(10, 10))
+    >>> A = LinOp.from_array(mat).gram()
+    >>> # Create the ground truth 'x_star'
+    >>> x_star = rng.normal(size=(2, 2, 10))
+    >>> # Generate the corresponding data vector 'b'
+    >>> b = A.apply(x_star)
+    >>> # Solve 'Ax=b' for 'x' with the conjugate gradient method
+    >>> lsqr = LSQR(A, show_progress=False)
+    >>> lsqr.fit(b=b)
+    >>> x_solution = lsqr.solution()
+    >>> assert np.allclose(x_star, x_solution)
+    True
+
+    **References:**
+
+    .. [1] S.-C. Choi, "Iterative Methods for Singular Linear Equations
+        and Least-Squares Problems", Dissertation,
+        http://www.stanford.edu/group/SOL/dissertations/sou-cheng-choi-thesis.pdf
     """
 
     def __init__(
@@ -116,20 +127,25 @@ class LSQR(pycs.Solver):
         x0: typ.Optional[pyct.NDArray] = None,
     ):
         xp = pycu.get_array_module(b)
+
+        b = xp.atleast_1d(b)
+        if b.ndim > 1:
+            b = b.squeeze()
+        m, n = self._A.shape
+
         mst = self._mstate
-        mst["anorm"] = mst["acond"] = mst["res2"] = mst["xnorm"] = mst["xxnorm"] = 0
-        mst["ddnorm"] = mst["z"] = mst["sn2"] = 0
-        mst["cs2"] = -1
+        mst["normA"] = mst["condA"] = mst["res2"] = mst["xnorm"] = mst["xxnorm"] = 0.0
+        mst["ddnorm"] = mst["z"] = mst["sn2"] = 0.0
+        mst["cs2"] = -1.0
 
         u = b
         bnorm = xp.linalg.norm(b)
 
         if x0 is None:
-            # TODO: make sure shape is correct
-            x = xp.zeros((self._A.shape[1],))
+            x = xp.zeros(n)
             beta = bnorm.copy()
         else:
-            x = x0
+            x = xp.asarray(x0)
             u = u - self._A.apply(x)
             beta = xp.linalg.norm(u)
 
@@ -144,13 +160,22 @@ class LSQR(pycs.Solver):
         if alpha > 0:
             v = (1 / alpha) * v
 
+        arnorm = alpha * beta
+        if arnorm == 0:
+            mst["trivial"] = True
+            if b.ndim == 1:
+                mst["x"] = xp.zeros(n)
+            elif b.ndim == 2:
+                mst["x"] = xp.zeros((b.shape[0], n))
+            return
+
         mst["x"] = x
         mst["u"], mst["v"] = u, v
         mst["w"] = v.copy()
         mst["rhobar"] = mst["alpha"] = alpha
-        mst["phibar"] = mst["rnorm"] = mst["r1norm"] = mst["r2norm"] = beta
-        mst["arnorm"], mst["bnorm"] = alpha * beta, bnorm
-        mst["itn"], mst["istop"] = 0, None
+        mst["phibar"] = mst["rnorm"] = mst["normr1"] = mst["normr2"] = beta
+        mst["bnorm"] = bnorm
+        mst["trivial"] = False
         mst["test1"], mst["test2"] = 1.0, alpha / beta
         mst["test3"] = mst["t1"] = mst["rtol"] = None
 
@@ -178,10 +203,13 @@ class LSQR(pycs.Solver):
     def m_step(self):
 
         mst = self._mstate  # shorthand
+        if mst["trivial"]:
+            return
         xp = pycu.get_array_module(mst["x"])
+
         x, u, v, w = mst["x"], mst["u"], mst["v"], mst["w"]
         alpha, rhobar, phibar = mst["alpha"], mst["rhobar"], mst["phibar"]
-        anorm, ddnorm, xxnorm, bnorm = mst["anorm"], mst["ddnorm"], mst["xxnorm"], mst["bnorm"]
+        normA, ddnorm, xxnorm, bnorm = mst["normA"], mst["ddnorm"], mst["xxnorm"], mst["bnorm"]
         res2, sn2, cs2, z = mst["res2"], mst["sn2"], mst["cs2"], mst["z"]
 
         # Bidiagonalizaion to obtain next beta, u, alpha, v
@@ -190,7 +218,7 @@ class LSQR(pycs.Solver):
 
         if beta > 0:
             u = (1 / beta) * u
-            anorm = xp.sqrt(anorm**2 + alpha**2 + beta**2 + self._dampsq)
+            normA = xp.sqrt(normA**2 + alpha**2 + beta**2 + self._dampsq)
             v = self._A.T.apply(u) - beta * v
             alpha = xp.linalg.norm(v)
             if alpha > 0:
@@ -239,7 +267,7 @@ class LSQR(pycs.Solver):
         z = rhs / gamma
         xxnorm = xxnorm + z**2
 
-        acond = anorm * xp.sqrt(ddnorm)
+        condA = normA * xp.sqrt(ddnorm)
         res1 = phibar**2
         res2 = res2 + psi**2
         rnorm = xp.sqrt(res1 + res2)
@@ -248,29 +276,30 @@ class LSQR(pycs.Solver):
         # Distinguish residual norms
         if self._damp > 0:
             r1sq = rnorm**2 - self._dampsq * xxnorm
-            r1norm = xp.sqrt(xp.abs(r1sq))
+            normr1 = xp.sqrt(xp.abs(r1sq))
             if r1sq < 0:
-                r1norm = -r1norm
+                normr1 = -normr1
         else:
-            r1norm = rnorm
-        r2norm = rnorm
+            normr1 = rnorm
+        normr2 = rnorm
 
         # Get necessary metrics for convergence test
         test1 = rnorm / bnorm
-        test2 = arnorm / (anorm * rnorm + self._eps)
-        test3 = 1 / (acond + self._eps)
-        t1 = test1 / (1 + anorm * xnorm / bnorm)
-        rtol = self._btol + self._atol * anorm * xnorm / bnorm
+        test2 = arnorm / (normA * rnorm + self._eps)
+        test3 = 1 / (condA + self._eps)
+        t1 = test1 / (1 + normA * xnorm / bnorm)
+        rtol = self._btol + self._atol * normA * xnorm / bnorm
 
         # Store necessary parameters
-        mst["anorm"], mst["ddnorm"], mst["xnorm"], mst["xxnorm"], mst["bnorm"] = anorm, ddnorm, xnorm, xxnorm, bnorm
+        mst["normA"], mst["ddnorm"], mst["xnorm"], mst["xxnorm"], mst["bnorm"] = normA, ddnorm, xnorm, xxnorm, bnorm
         mst["res2"], mst["sn2"], mst["cs2"], mst["z"] = res2, sn2, cs2, z
         mst["test1"], mst["test2"], mst["test3"] = test1, test2, test3
         mst["t1"], mst["rtol"] = t1, rtol
-        mst["r1norm"], mst["r2norm"], mst["acond"] = r1norm, r2norm, acond
+        mst["normr1"], mst["normr2"], mst["condA"] = normr1, normr2, condA
 
     def default_stop_crit(self) -> pycs.StoppingCriterion:
-        stop_crit = pycos.StopCriterion_LSQR(
+        stop_crit = pycos.StopCriterion_LSQMR(
+            method="lsqr",
             atol=self._atol,
             ctol=self._ctol,
             itn=0,

--- a/src/pycsou/opt/solver/lsqr.py
+++ b/src/pycsou/opt/solver/lsqr.py
@@ -81,9 +81,9 @@ class LSQR(pycs.Solver):
 
     **References:**
 
-    .. [1] S.-C. Choi, "Iterative Methods for Singular Linear Equations
-        and Least-Squares Problems", Dissertation,
-        http://www.stanford.edu/group/SOL/dissertations/sou-cheng-choi-thesis.pdf
+    .. [1] C. C. Paige and M. A. Saunders "LSQR: An algorithm for sparse linear
+        equations and sparse least squares", Dissertation,
+        https://web.stanford.edu/group/SOL/software/lsqr/lsqr-toms82a.pdf
     """
 
     def __init__(

--- a/src/pycsou/opt/solver/lsqr.py
+++ b/src/pycsou/opt/solver/lsqr.py
@@ -1,0 +1,290 @@
+import typing as typ
+
+import numpy as np
+
+import pycsou.abc.operator as pyco
+import pycsou.abc.solver as pycs
+import pycsou.opt.stop as pycos
+import pycsou.runtime as pycrt
+import pycsou.util as pycu
+import pycsou.util.ptype as pyct
+
+
+class LSQR(pycs.Solver):
+    r"""
+     LSQR Method.
+
+     The LSQR method solves the system of linear equations :math:`\mathbf{A}\mathbf{x}=\mathbf{b}` iteratively.
+     :math:`\mathbf{A}` is a rectangular matrix of dimension m-by-n, where all cases are allowed: m=n, m>n or m<n.
+     :math:`\mathbf{b}` is a vector of length m. The matrix :math:`\mathbf{A}` may be square or rectangular and may have
+     any rank.
+     For unsymmetric equations, it solves :math:`\mathbf{A}\mathbf{x}=\mathbf{b}`.
+     For linear least squares, it solves :math:`||\mathbf{b}-\mathbf{A}\mathbf{x}||^2`.
+     For damped least squares, it solves :math:`||\mathbf{b}-\mathbf{A}\mathbf{x}||^2 + d^2 ||\mathbf{x}-\mathbf{x_0}||
+     ^2`.
+
+
+     ``CG()`` **Parameterization**
+     A: pycsou.abc.operator.PosDefOp
+        Any positive definite linear operator is accepted.
+     damp: float
+        Damping coefficient. Default is 0.
+     atol, btol: float
+        Stopping tolerances. LSQR continues iterations until a certain backward error estimate is smaller than some
+        quantity depending on atol and btol. Default is 1e-6 for both.
+     conlim: float
+        LSQR terminates if an estimate :math:`cond(\mathbf{A})` exceeds conlim. Default is 1e8.
+     iter_lim: int, optional
+        LSQR terminates if the number of iterations reaches iter_lim. Default is None.
+
+     ``CG.fit()`` **Parameterization**
+
+     b: NDArray
+         (..., N) 'b' terms in the LSQR cost function. All problems are solved in parallel.
+     x0: NDArray
+        (..., N) initial point(s). Defaults to 0 if unspecified.
+     restart_rate: int
+        Number of iterations after which restart is applied. By default, restart is done after 'n' iterations, where 'n'
+        corresponds to the dimension of the linear operator :math:`\mathbf{A}`.
+
+    **Remark:** In pycsou.opt.solver.stop, StopCriterion_LSQR is developed for the stopping criterion of LSQR. For
+    computational speed, explicit norms were not computated. Instead, their estimation was used, which is referred from
+    [1].
+
+     References
+     ----------
+        [1] S.-C. Choi, "Iterative Methods for Singular Linear Equations
+            and Least-Squares Problems", Dissertation,
+            http://www.stanford.edu/group/SOL/dissertations/sou-cheng-choi-thesis.pdf
+     Examples
+     --------
+     >>> import numpy as np
+     >>> from pycsou.abc import LinOp
+     >>> # Create a PSD linear operator
+     >>> rng = np.random.default_rng(seed=0)
+     >>> mat = rng.normal(size=(10, 10))
+     >>> A = LinOp.from_array(mat).gram()
+     >>> # Create the ground truth 'x_star'
+     >>> x_star = rng.normal(size=(2, 2, 10))
+     >>> # Generate the corresponding data vector 'b'
+     >>> b = A.apply(x_star)
+     >>> # Solve 'Ax=b' for 'x' with the conjugate gradient method
+     >>> lsqr = LSQR(A, show_progress=False)
+     >>> lsqr.fit(b=b)
+     >>> x_solution = lsqr.solution()
+     >>> assert np.allclose(x_star, x_solution)
+    """
+
+    def __init__(
+        self,
+        A: pyco.PosDefOp,
+        *,
+        damp: float = 0.0,
+        atol: float = 1e-06,
+        btol: float = 1e-06,
+        conlim: float = 1e08,
+        iter_lim: typ.Optional[int] = None,
+        eps: float = np.finfo(np.float64).eps,
+        folder: typ.Optional[pyct.PathLike] = None,
+        exist_ok: bool = False,
+        writeback_rate: typ.Optional[int] = None,
+        verbosity: int = 1,
+        show_progress: bool = True,
+        log_var: pyct.VarName = ("x",),
+    ):
+        super().__init__(
+            folder=folder,
+            exist_ok=exist_ok,
+            writeback_rate=writeback_rate,
+            verbosity=verbosity,
+            show_progress=show_progress,
+            log_var=log_var,
+        )
+
+        self._A = A
+        self._atol = atol
+        self._btol = btol
+        self._ctol = (1.0 / conlim) if (conlim > 0) else 0.0
+        self._iter_lim = (2 * A.shape[1]) if (iter_lim is None) else iter_lim
+        self._dampsq, self._damp = damp**2, damp
+        self._eps = eps
+
+    @pycrt.enforce_precision(i=["b", "x0"], allow_None=True)
+    def m_init(
+        self,
+        b: pyct.NDArray,
+        x0: typ.Optional[pyct.NDArray] = None,
+    ):
+        xp = pycu.get_array_module(b)
+        mst = self._mstate
+        mst["anorm"] = mst["acond"] = mst["res2"] = mst["xnorm"] = mst["xxnorm"] = 0
+        mst["ddnorm"] = mst["z"] = mst["sn2"] = 0
+        mst["cs2"] = -1
+
+        u = b
+        bnorm = xp.linalg.norm(b)
+
+        if x0 is None:
+            # TODO: make sure shape is correct
+            x = xp.zeros((self._A.shape[1],))
+            beta = bnorm.copy()
+        else:
+            x = x0
+            u = u - self._A.apply(x)
+            beta = xp.linalg.norm(u)
+
+        if beta > 0:
+            u = (1 / beta) * u
+            v = self._A.T.apply(u)
+            alpha = xp.linalg.norm(v)
+        else:
+            v = x.copy()
+            alpha = 0
+
+        if alpha > 0:
+            v = (1 / alpha) * v
+
+        mst["x"] = x
+        mst["u"], mst["v"] = u, v
+        mst["w"] = v.copy()
+        mst["rhobar"] = mst["alpha"] = alpha
+        mst["phibar"] = mst["rnorm"] = mst["r1norm"] = mst["r2norm"] = beta
+        mst["arnorm"], mst["bnorm"] = alpha * beta, bnorm
+        mst["itn"], mst["istop"] = 0, None
+        mst["test1"], mst["test2"] = 1.0, alpha / beta
+        mst["test3"] = mst["t1"] = mst["rtol"] = None
+
+    @staticmethod
+    def _sym_ortho(a, b, xp):
+        """
+        Stable implementation of Givens rotation.
+        """
+        if b == 0:
+            return xp.sign(a), 0, xp.abs(a)
+        elif a == 0:
+            return 0, xp.sign(b), xp.abs(b)
+        elif xp.abs(b) > xp.abs(a):
+            tau = a / b
+            s = xp.sign(b) / xp.sqrt(1 + tau * tau)
+            c = s * tau
+            r = b / s
+        else:
+            tau = b / a
+            c = xp.sign(a) / xp.sqrt(1 + tau * tau)
+            s = c * tau
+            r = a / c
+        return c, s, r
+
+    def m_step(self):
+
+        mst = self._mstate  # shorthand
+        xp = pycu.get_array_module(mst["x"])
+        x, u, v, w = mst["x"], mst["u"], mst["v"], mst["w"]
+        alpha, rhobar, phibar = mst["alpha"], mst["rhobar"], mst["phibar"]
+        anorm, ddnorm, xxnorm, bnorm = mst["anorm"], mst["ddnorm"], mst["xxnorm"], mst["bnorm"]
+        res2, sn2, cs2, z = mst["res2"], mst["sn2"], mst["cs2"], mst["z"]
+
+        # Bidiagonalizaion to obtain next beta, u, alpha, v
+        u = self._A.apply(v) - alpha * u
+        beta = xp.linalg.norm(u)
+
+        if beta > 0:
+            u = (1 / beta) * u
+            anorm = xp.sqrt(anorm**2 + alpha**2 + beta**2 + self._dampsq)
+            v = self._A.T.apply(u) - beta * v
+            alpha = xp.linalg.norm(v)
+            if alpha > 0:
+                v = (1 / alpha) * v
+
+        # Plane rotation to eliminate the damping parameter
+        if self._damp > 0:
+            rhobar1 = xp.sqrt(rhobar**2 + self._dampsq)
+            cs1 = rhobar / rhobar1
+            sn1 = self._damp / rhobar1
+            psi = sn1 * phibar
+            phibar = cs1 * phibar
+        else:
+            rhobar1 = rhobar
+            psi = 0
+
+        # Plane rotation to eliminate the subdiagonal element of lower-bidiagonal matrix
+        cs, sn, rho = self._sym_ortho(rhobar1, beta, xp)
+
+        theta = sn * alpha
+        rhobar = -cs * alpha
+        phi = cs * phibar
+        phibar = sn * phibar
+        tau = sn * phi
+
+        # Update x and w
+        t1 = phi / rho
+        t2 = -theta / rho
+        dk = (1 / rho) * w
+        x = x + t1 * w
+        w = v + t2 * w
+
+        mst["x"], mst["u"], mst["v"], mst["w"] = x, u, v, w
+        mst["alpha"], mst["rhobar"], mst["phibar"] = alpha, rhobar, phibar
+
+        # Estimation of norms:
+        ddnorm = ddnorm + xp.linalg.norm(dk) ** 2
+        delta = sn2 * rho
+        gambar = -cs2 * rho
+        rhs = phi - delta * z
+        zbar = rhs / gambar
+        xnorm = xp.sqrt(xxnorm + zbar**2)
+        gamma = xp.sqrt(gambar**2 + theta**2)
+        cs2 = gambar / gamma
+        sn2 = theta / gamma
+        z = rhs / gamma
+        xxnorm = xxnorm + z**2
+
+        acond = anorm * xp.sqrt(ddnorm)
+        res1 = phibar**2
+        res2 = res2 + psi**2
+        rnorm = xp.sqrt(res1 + res2)
+        arnorm = alpha * abs(tau)
+
+        # Distinguish residual norms
+        if self._damp > 0:
+            r1sq = rnorm**2 - self._dampsq * xxnorm
+            r1norm = xp.sqrt(xp.abs(r1sq))
+            if r1sq < 0:
+                r1norm = -r1norm
+        else:
+            r1norm = rnorm
+        r2norm = rnorm
+
+        # Get necessary metrics for convergence test
+        test1 = rnorm / bnorm
+        test2 = arnorm / (anorm * rnorm + self._eps)
+        test3 = 1 / (acond + self._eps)
+        t1 = test1 / (1 + anorm * xnorm / bnorm)
+        rtol = self._btol + self._atol * anorm * xnorm / bnorm
+
+        # Store necessary parameters
+        mst["anorm"], mst["ddnorm"], mst["xnorm"], mst["xxnorm"], mst["bnorm"] = anorm, ddnorm, xnorm, xxnorm, bnorm
+        mst["res2"], mst["sn2"], mst["cs2"], mst["z"] = res2, sn2, cs2, z
+        mst["test1"], mst["test2"], mst["test3"] = test1, test2, test3
+        mst["t1"], mst["rtol"] = t1, rtol
+        mst["r1norm"], mst["r2norm"], mst["acond"] = r1norm, r2norm, acond
+
+    def default_stop_crit(self) -> pycs.StoppingCriterion:
+        stop_crit = pycos.StopCriterion_LSQR(
+            atol=self._atol,
+            ctol=self._ctol,
+            itn=0,
+            iter_lim=self._iter_lim,
+        )
+
+        return stop_crit
+
+    def solution(self) -> pyct.NDArray:
+        """
+        Returns
+        -------
+        p: NDArray
+            (..., N) solution.
+        """
+        data, _ = self.stats()
+        return data.get("x")

--- a/src/pycsou/opt/stop.py
+++ b/src/pycsou/opt/stop.py
@@ -278,3 +278,146 @@ class RelError(pycs.StoppingCriterion):
     def clear(self):
         self._val = np.r_[0]
         self._x_prev = None
+
+
+class StopCriterion_LSQR(pycs.StoppingCriterion):
+    """
+    TODO: Write Description here
+    """
+
+    def __init__(
+        self,
+        atol: float,
+        ctol: float,
+        itn: int,
+        iter_lim: int,
+    ):
+        """
+        Parameters
+        ----------
+        eps: float
+            Positive threshold.
+        satisfy_all: bool
+            If True (default) and `Solver._mstate[var]` is multi-dimensional, stop if all evaluation
+            points lie below threshold.
+        """
+        self._atol, self._ctol = atol, ctol
+        self._itn, self._iter_lim = itn, iter_lim
+        self._istop = 0
+        self._x0 = self._test1 = self._test2 = None
+        self._r1norm = self._r2norm = self._anorm = self._acond = None
+
+    def stop(self, state: cabc.Mapping) -> bool:
+        test1, test2, test3 = state["test1"], state["test2"], state["test3"]
+        self._x0, self._test1, self._test2 = state["x"][0], test1, test2
+        self._r1norm, self._r2norm = state["r1norm"], state["r2norm"]
+        if self._itn == 0:
+            self._itn += 1
+            return False
+
+        t1, rtol = state["t1"], state["rtol"]
+        self._anorm = state["anorm"]
+        self._acond = state["acond"]
+
+        if self._itn >= self._iter_lim:
+            self._istop = 7
+        if 1 + test3 <= 1:
+            self._istop = 6
+        if test3 <= self._ctol:
+            self._istop = 3
+        if 1 + test2 <= 1:
+            self._istop = 5
+        if test2 <= self._atol:
+            self._istop = 2
+        if test1 <= rtol:
+            self._istop = 1
+        if 1 + t1 <= 1:
+            self._istop = 4
+
+        self._itn += 1
+
+        decision = self._istop != 0
+        return decision
+
+    def info(self) -> cabc.Mapping[str, float]:
+        data = {
+            f"x[0]": self._x0,
+            f"r1norm": self._r1norm,
+            f"r2norm": self._r2norm,
+            f"Compatible": self._test1,
+            f"LS": self._test2,
+            f"Norm A": self._anorm,
+            f"Cond A": self._acond,
+        }
+        return data
+
+
+class StopCriterion_LSMR(pycs.StoppingCriterion):
+    """
+    TODO: Write Description here
+    """
+
+    def __init__(
+        self,
+        atol: float,
+        ctol: float,
+        itn: int,
+        iter_lim: int,
+    ):
+        """
+        Parameters
+        ----------
+        eps: float
+            Positive threshold.
+        satisfy_all: bool
+            If True (default) and `Solver._mstate[var]` is multi-dimensional, stop if all evaluation
+            points lie below threshold.
+        """
+        self._atol, self._ctol = atol, ctol
+        self._itn, self._iter_lim = itn, iter_lim
+        self._istop = 0
+        self._x0 = self._test1 = self._test2 = None
+        self._normr = self._normar = self._normA = self._condA = None
+
+    def stop(self, state: cabc.Mapping) -> bool:
+        test1, test2, test3 = state["test1"], state["test2"], state["test3"]
+        self._x0, self._test1, self._test2 = state["x"][0], test1, test2
+        self._normr, self._normar = state["normr"], state["normar"]
+        if self._itn == 0:
+            self._itn += 1
+            return False
+
+        t1, rtol = state["t1"], state["rtol"]
+        self._normA, self._condA = state["normA"], state["condA"]
+
+        if self._itn >= self._iter_lim:
+            self._istop = 7
+        if 1 + test3 <= 1:
+            self._istop = 6
+        if test3 <= self._ctol:
+            self._istop = 3
+        if 1 + test2 <= 1:
+            self._istop = 5
+        if test2 <= self._atol:
+            self._istop = 2
+        if test1 <= rtol:
+            self._istop = 1
+        if 1 + t1 <= 1:
+            self._istop = 4
+
+        self._itn += 1
+
+        decision = self._istop != 0
+        return decision
+
+    def info(self) -> cabc.Mapping[str, float]:
+        data = {
+            f"x[0]": self._x0,
+            f"r1norm": self._normr,
+            f"r2norm": self._normar,
+            f"Compatible": self._test1,
+            f"LS": self._test2,
+            f"Norm A": self._normA,
+            f"Cond A": self._condA,
+        }
+        return data


### PR DESCRIPTION
* Theory behind LSQR and LSMR and their implementation is studied by Stanford articles: [LSQR](https://web.stanford.edu/group/SOL/software/lsqr/lsqr-toms82a.pdf) and [LSMR](https://web.stanford.edu/group/SOL/software/lsmr/LSMR-SISC-2011.pdf). All estimation methods, stopping criterions are implemented from these techniques. 
* `LSQR` and `LSMR` classes are implemented in `lsqr.py` and `lsmr.py` with the inspiration from [scipy.sparse.linalg.lsqr](https://github.com/scipy/scipy/blob/v1.8.1/scipy/sparse/linalg/_isolve/lsqr.py#L96-L586) and [scipy.sparse.linalg.lsmr](https://github.com/scipy/scipy/blob/v1.8.1/scipy/sparse/linalg/_isolve/lsmr.py#L29-L485).
* `StopCriterion_LSQMR` class is implemented in `stop.py`. This is the customized stopping criterion to work with LSQR and LSMR.
* `LSQR` and `LSMR` work with multiple inputs and the solution is obtained in parallel.
* Documentation for each solvers and stopping criterion are done.