### PR TITLE
[nlcg][linesearch] Added the non-linear conjugate gradient method to Pycsou.

### DIFF
--- a/doc/pycsou.math.rst
+++ b/doc/pycsou.math.rst
@@ -12,6 +12,14 @@ pycsou.math.linalg module
    :undoc-members:
    :show-inheritance:
 
+pycsou.math.linesearch module
+-----------------------------
+
+.. automodule:: pycsou.math.linesearch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/doc/pycsou.opt.solver.rst
+++ b/doc/pycsou.opt.solver.rst
@@ -20,6 +20,14 @@ pycsou.opt.solver.cg module
    :undoc-members:
    :show-inheritance:
 
+pycsou.opt.solver.nlcg module
+-----------------------------
+
+.. automodule:: pycsou.opt.solver.nlcg
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pycsou.opt.solver.pds module
 ----------------------------
 

--- a/src/pycsou/math/__init__.py
+++ b/src/pycsou/math/__init__.py
@@ -1,1 +1,2 @@
 from pycsou.math.linalg import *
+from pycsou.math.linesearch import *

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -15,7 +15,9 @@ def backtracking_linesearch(
     r: pyct.Real = LINESEARCH_DEFAULT_R,
     c: pyct.Real = LINESEARCH_DEFAULT_C,
 ) -> pyct.Real:
-
+    r"""
+    Backtracking line search algorithm.
+    """
     # document where default values come from (continuous opti course)
 
     def default_if_none(v, default_v):

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -26,11 +26,11 @@ def backtracking_linesearch(
     f: pyca.DiffFunc
         Differentiable functional
     x: pyct.NDArray
-        (..., N) initial search position(s)
+        (N,) initial search position
     g_f_x: pyct.NDArray
-        (..., N) gradient of `f` at initial search position(s)
+        (N,) gradient of `f` at initial search position(s)
     p: pyct.NDArray
-        (..., N) search direction(s)
+        (N,) search direction(s)
     a_bar: pyct.Real
         Initial step size, defaults to 1
     r: pyct.Real
@@ -47,7 +47,7 @@ def backtracking_linesearch(
     c = default_if_none(c, LINESEARCH_DEFAULT_C)
 
     f_x = f.apply(x)
-    scalar_prod = c * (g_f_x @ p)
+    scalar_prod = c * (p @ g_f_x)
 
     while f.apply(x + a * p) > f_x + a * scalar_prod:
         a = r * a

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -14,6 +14,10 @@ LINESEARCH_DEFAULT_R = 0.5
 LINESEARCH_DEFAULT_C = 1e-4
 
 
+@pycrt.enforce_precision(
+    i=("x", "direction", "gradient", "a0", "r", "c"),
+    allow_None=True,
+)
 def backtracking_linesearch(
     f: pyca.DiffFunc,
     x: pyct.NDArray,

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -15,8 +15,8 @@ LINESEARCH_DEFAULT_C = 10e-4
 def backtracking_linesearch(
     f: pyca.DiffFunc,
     x: pyct.NDArray,
-    g: pyct.NDArray,
-    p: pyct.NDArray,
+    gradient: pyct.NDArray,
+    direction: pyct.NDArray,
     a_bar: pyct.Real = LINESEARCH_DEFAULT_A_BAR,
     r: pyct.Real = LINESEARCH_DEFAULT_R,
     c: pyct.Real = LINESEARCH_DEFAULT_C,
@@ -31,9 +31,9 @@ def backtracking_linesearch(
         Differentiable functional
     x: pyct.NDArray
         (..., N) initial search point(s)
-    g: pyct.NDArray
+    gradient: pyct.NDArray
         (..., N) gradient of `f` at initial search point(s)
-    p: pyct.NDArray
+    direction: pyct.NDArray
         (..., N) search direction(s) corresponding to initial point(s)
     a_bar: pyct.Real
         Initial step size.
@@ -64,14 +64,14 @@ def backtracking_linesearch(
     c = correct_shape(c, LINESEARCH_DEFAULT_C)
 
     f_x = f.apply(x)
-    scalar_prod = c * dot_prod_last_axis(g, p)
-    f_x_ap = f.apply(x + a_bar * p)
+    scalar_prod = c * dot_prod_last_axis(gradient, direction)
+    f_x_ap = f.apply(x + a_bar * direction)
     a_prod = coeff_rows_multip(a, scalar_prod)
     cond = f_x_ap > f_x + a_prod
 
     while xp.any(cond):
         a = xp.where(cond, r * a, a)
-        f_x_ap = f.apply(x + a * p)
+        f_x_ap = f.apply(x + a * direction)
         a_prod = coeff_rows_multip(a, scalar_prod)
         cond = f_x_ap > f_x + a_prod
 

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -45,7 +45,7 @@ def backtracking_linesearch(
     Returns
     -------
     a: pyct.NDArray
-        (N,) step sizes.
+        (..., 1) step sizes.
     """
 
     xp = pycu.get_array_module(x)

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -10,7 +10,7 @@ LINESEARCH_DEFAULT_C = 10e-4
 def backtracking_linesearch(
     f: pyca.DiffFunc,
     x: pyct.NDArray,
-    g_f_x: pyct.NDArray,
+    g: pyct.NDArray,
     p: pyct.NDArray,
     a_bar=LINESEARCH_DEFAULT_A_BAR,
     r=LINESEARCH_DEFAULT_R,
@@ -28,7 +28,7 @@ def backtracking_linesearch(
         Differentiable functional
     x: pyct.NDArray
         (..., N) initial search position(s)
-    g_f_x: pyct.NDArray
+    g: pyct.NDArray
         (..., N) gradient of `f` at initial search position(s)
     p: pyct.NDArray
         (..., N) search direction(s) corresponding to the initial search position(s)
@@ -56,7 +56,7 @@ def backtracking_linesearch(
     c = correct_shape(c, LINESEARCH_DEFAULT_C)
 
     f_x = f.apply(x)
-    scalar_prod = c * dot_prod_last_axis(g_f_x, p)
+    scalar_prod = c * dot_prod_last_axis(g, p)
     f_x_ap = f.apply(x + a_bar * p)
     a_prod = coeff_rows_multip(a, scalar_prod)
     cond = f_x_ap > f_x + a_prod

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -2,6 +2,11 @@ import pycsou.abc as pyca
 import pycsou.util as pycu
 import pycsou.util.ptype as pyct
 
+__all__ = [
+    "backtracking_linesearch",
+]
+
+
 LINESEARCH_DEFAULT_A_BAR = 1.0
 LINESEARCH_DEFAULT_R = 0.5
 LINESEARCH_DEFAULT_C = 10e-4

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -15,8 +15,8 @@ LINESEARCH_DEFAULT_C = 10e-4
 def backtracking_linesearch(
     f: pyca.DiffFunc,
     x: pyct.NDArray,
-    gradient: pyct.NDArray,
     direction: pyct.NDArray,
+    gradient: pyct.NDArray = None,
     a_bar: pyct.Real = None,
     r: pyct.Real = LINESEARCH_DEFAULT_R,
     c: pyct.Real = LINESEARCH_DEFAULT_C,
@@ -31,10 +31,13 @@ def backtracking_linesearch(
         Differentiable functional
     x: pyct.NDArray
         (..., N) initial search point(s)
-    gradient: pyct.NDArray
-        (..., N) gradient of `f` at initial search point(s)
     direction: pyct.NDArray
         (..., N) search direction(s) corresponding to initial point(s)
+    gradient: pyct.NDArray
+        (..., N) gradient of `f` at initial search point(s)
+
+        Specifying `gradient` when known is an optimization:
+        it will be autocomputed via ``f.grad(x)`` if unspecified.
     a_bar: pyct.Real
         Initial step size.
 
@@ -69,6 +72,8 @@ def backtracking_linesearch(
             # f is linear -> line-search unbounded
             raise ValueError("Line-search does not converge for linear functionals.")
 
+    if gradient is None:
+        gradient = f.grad(x)
 
     a = correct_shape(a_bar, LINESEARCH_DEFAULT_A_BAR)
     r = correct_shape(r, LINESEARCH_DEFAULT_R)

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -12,32 +12,35 @@ def backtracking_linesearch(
     x: pyct.NDArray,
     g: pyct.NDArray,
     p: pyct.NDArray,
-    a_bar=LINESEARCH_DEFAULT_A_BAR,
-    r=LINESEARCH_DEFAULT_R,
-    c=LINESEARCH_DEFAULT_C,
-):
+    a_bar: pyct.Real = LINESEARCH_DEFAULT_A_BAR,
+    r: pyct.Real = LINESEARCH_DEFAULT_R,
+    c: pyct.Real = LINESEARCH_DEFAULT_C,
+) -> pyct.NDArray:
     r"""
-    Backtracking line search algorithm based on the Armijo-Goldstein condition.
+    Backtracking line search algorithm based on the
+    `Armijo-Goldstein condition <https://www.wikiwand.com/en/Backtracking_line_search>`_.
 
-    Follow `this link <https://www.wikiwand.com/en/Backtracking_line_search>`_ for reference of the algorithm and
-    default values.
-
-    **Parameterization**
-
+    Parameters
+    ----------
     f: pyca.DiffFunc
         Differentiable functional
     x: pyct.NDArray
-        (..., N) initial search position(s)
+        (..., N) initial search point(s)
     g: pyct.NDArray
-        (..., N) gradient of `f` at initial search position(s)
+        (..., N) gradient of `f` at initial search point(s)
     p: pyct.NDArray
-        (..., N) search direction(s) corresponding to the initial search position(s)
+        (..., N) search direction(s) corresponding to initial point(s)
     a_bar: pyct.Real
-        Initial step size, defaults to 1
+        Initial step size.
     r: pyct.Real
-        Step reduction factor, defaults to 0.5
+        Step reduction factor.
     c: pyct:Real
-        Bound reduction factor, defaults to 10e-4
+        Bound reduction factor.
+
+    Returns
+    -------
+    a: pyct.NDArray
+        (N,) step sizes.
     """
 
     xp = pycu.get_array_module(x)

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import pycsou.abc as pyca
 import pycsou.runtime as pycrt
 import pycsou.util as pycu
@@ -59,8 +61,11 @@ def backtracking_linesearch(
     def coeff_rows_multip(coeffs, rows):
         return xp.transpose(xp.transpose(rows) * coeffs)
 
-    def correct_shape(v, default_v):
-        return v if v not in [default_v, None] else xp.full(x.shape[:-1], default_v, dtype=x.dtype)
+    def sanitize(v, default_v):
+        return v if v not in [default_v, None] else default_v
+
+    def correct_shape(v):
+        return xp.full((*x.shape[:-1], 1), v, dtype=x.dtype)
 
     def dot_prod_last_axis(v1, v2):
         return (v1 * v2).sum(axis=-1)
@@ -75,9 +80,9 @@ def backtracking_linesearch(
     if gradient is None:
         gradient = f.grad(x)
 
-    a = correct_shape(a_bar, LINESEARCH_DEFAULT_A_BAR)
-    r = correct_shape(r, LINESEARCH_DEFAULT_R)
-    c = correct_shape(c, LINESEARCH_DEFAULT_C)
+    a = correct_shape(a_bar)
+    r = correct_shape(sanitize(r, LINESEARCH_DEFAULT_R))
+    c = correct_shape(sanitize(c, LINESEARCH_DEFAULT_C))
 
     f_x = f.apply(x)
     scalar_prod = c * dot_prod_last_axis(gradient, direction)

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -1,5 +1,5 @@
 import pycsou.abc as pyca
-import pycsou.util.array_module as pyarr
+import pycsou.util as pycu
 import pycsou.util.ptype as pyct
 
 LINESEARCH_DEFAULT_A_BAR = 1.0
@@ -40,7 +40,7 @@ def backtracking_linesearch(
         Bound reduction factor, defaults to 10e-4
     """
 
-    xp = pyarr.get_array_module(x)
+    xp = pycu.get_array_module(x)
 
     def coeff_rows_multip(coeffs, rows):
         return xp.transpose(xp.transpose(rows) * coeffs)

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -40,13 +40,13 @@ def backtracking_linesearch(
         Bound reduction factor, defaults to 10e-4
     """
 
-    arrmod = pyarr.get_array_module(x)
+    xp = pyarr.get_array_module(x)
 
     def coeff_rows_multip(coeffs, rows):
-        return arrmod.transpose(arrmod.transpose(rows) * coeffs)
+        return xp.transpose(xp.transpose(rows) * coeffs)
 
     def correct_shape(v, default_v):
-        return v if v not in [default_v, None] else arrmod.full(x.shape[:-1], default_v, dtype=x.dtype)
+        return v if v not in [default_v, None] else xp.full(x.shape[:-1], default_v, dtype=x.dtype)
 
     def dot_prod_last_axis(v1, v2):
         return (v1 * v2).sum(axis=-1)
@@ -61,8 +61,8 @@ def backtracking_linesearch(
     a_prod = coeff_rows_multip(a, scalar_prod)
     cond = f_x_ap > f_x + a_prod
 
-    while arrmod.any(cond):
-        a = arrmod.where(cond, r * a, a)
+    while xp.any(cond):
+        a = xp.where(cond, r * a, a)
         f_x_ap = f.apply(x + a * p)
         a_prod = coeff_rows_multip(a, scalar_prod)
         cond = f_x_ap > f_x + a_prod

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import pycsou.abc as pyca
 import pycsou.util as pycu
 import pycsou.util.ptype as pyct
@@ -7,7 +9,6 @@ __all__ = [
 ]
 
 
-LINESEARCH_DEFAULT_A_BAR = 1.0
 LINESEARCH_DEFAULT_R = 0.5
 LINESEARCH_DEFAULT_C = 10e-4
 
@@ -15,9 +16,9 @@ LINESEARCH_DEFAULT_C = 10e-4
 def backtracking_linesearch(
     f: pyca.DiffFunc,
     x: pyct.NDArray,
-    g: pyct.NDArray,
-    p: pyct.NDArray,
-    a_bar: pyct.Real = LINESEARCH_DEFAULT_A_BAR,
+    direction: pyct.NDArray,
+    gradient: pyct.NDArray = None,
+    a_bar: pyct.Real = None,
     r: pyct.Real = LINESEARCH_DEFAULT_R,
     c: pyct.Real = LINESEARCH_DEFAULT_C,
 ) -> pyct.NDArray:
@@ -25,18 +26,22 @@ def backtracking_linesearch(
     Backtracking line search algorithm based on the
     `Armijo-Goldstein condition <https://www.wikiwand.com/en/Backtracking_line_search>`_.
 
+    Performs a line search along the given direction(s).
+
     Parameters
     ----------
     f: pyca.DiffFunc
         Differentiable functional
     x: pyct.NDArray
         (..., N) initial search point(s)
-    g: pyct.NDArray
-        (..., N) gradient of `f` at initial search point(s)
-    p: pyct.NDArray
+    direction: pyct.NDArray
         (..., N) search direction(s) corresponding to initial point(s)
+    gradient: pyct.NDArray
+        (..., N) gradient of `f` at initial search point(s). Can be provided as
+        well as left as None.
     a_bar: pyct.Real
-        Initial step size.
+        Initial step size. If left None, will use :math:`\frac{1}{L}` where
+        L is a Lipschitz constant for :math:'\nabla f`
     r: pyct.Real
         Step reduction factor.
     c: pyct:Real
@@ -53,25 +58,41 @@ def backtracking_linesearch(
     def coeff_rows_multip(coeffs, rows):
         return xp.transpose(xp.transpose(rows) * coeffs)
 
-    def correct_shape(v, default_v):
-        return v if v not in [default_v, None] else xp.full(x.shape[:-1], default_v, dtype=x.dtype)
+    def sanitize(v, default_v):
+        return v if v not in [default_v, None] else default_v
+
+    def correct_shape(v):
+        return xp.full((*x.shape[:-1], 1), v, dtype=x.dtype)
 
     def dot_prod_last_axis(v1, v2):
         return (v1 * v2).sum(axis=-1)
 
-    a = correct_shape(a_bar, LINESEARCH_DEFAULT_A_BAR)
-    r = correct_shape(r, LINESEARCH_DEFAULT_R)
-    c = correct_shape(c, LINESEARCH_DEFAULT_C)
+    if a_bar is None:
+        d_l = f.diff_lipschitz()
+        if d_l is np.inf or d_l == 0:
+            raise ValueError(
+                "Either f gradient's lipschitz constant should be implemented through the diff_lipschitz"
+                "method or a maximal step size a_bar should be given as an argument to this line search."
+            )
+        else:
+            a_bar = 1.0 / f.diff_lipschitz()
+
+    if gradient is None:
+        gradient = f.grad(x)
+
+    a = correct_shape(a_bar)
+    r = correct_shape(sanitize(r, LINESEARCH_DEFAULT_R))
+    c = correct_shape(sanitize(c, LINESEARCH_DEFAULT_C))
 
     f_x = f.apply(x)
-    scalar_prod = c * dot_prod_last_axis(g, p)
-    f_x_ap = f.apply(x + a_bar * p)
+    scalar_prod = c * dot_prod_last_axis(gradient, direction)
+    f_x_ap = f.apply(x + a_bar * direction)
     a_prod = coeff_rows_multip(a, scalar_prod)
     cond = f_x_ap > f_x + a_prod
 
     while xp.any(cond):
         a = xp.where(cond, r * a, a)
-        f_x_ap = f.apply(x + a * p)
+        f_x_ap = f.apply(x + a * direction)
         a_prod = coeff_rows_multip(a, scalar_prod)
         cond = f_x_ap > f_x + a_prod
 

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -73,7 +73,7 @@ def backtracking_linesearch(
         gradient = f.grad(x)
 
     f_x = f.apply(x)
-    gradient_times_direction = (gradient * direction).sum(axis=-1, keepdims=True)
+    d_f = c * (gradient * direction).sum(axis=-1, keepdims=True)  # \delta f
 
     def refine(a: pyct.NDArray) -> pyct.NDArray:
         # Do one iteration of the algorithm.
@@ -88,9 +88,8 @@ def backtracking_linesearch(
         # mask : pyct.NDArray[bool]
         #     (..., 1) refinement points
         lhs = f.apply(x + a * direction)
-        rhs1 = f_x
-        rhs2 = (c * a) * gradient_times_direction
-        return lhs > rhs1 + rhs2  # mask
+        rhs = f_x + a * d_f
+        return lhs > rhs  # mask
 
     xp = pycu.get_array_module(x)
     a = xp.full(shape=(*x.shape[:-1], 1), fill_value=a0, dtype=x.dtype)

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -11,7 +11,7 @@ __all__ = [
 
 
 LINESEARCH_DEFAULT_R = 0.5
-LINESEARCH_DEFAULT_C = 10e-4
+LINESEARCH_DEFAULT_C = 1e-4
 
 
 def backtracking_linesearch(

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -1,0 +1,34 @@
+import pycsou.abc as pyca
+import pycsou.util.ptype as pyct
+
+LINESEARCH_DEFAULT_A_BAR = 1
+LINESEARCH_DEFAULT_R = 0.5
+LINESEARCH_DEFAULT_C = 10e-4
+
+
+def backtracking_linesearch(
+    f: pyca.DiffFunc,
+    x: pyct.NDArray,
+    g_f_x: pyct.NDArray,
+    p: pyct.NDArray,
+    a_bar: pyct.Real = LINESEARCH_DEFAULT_A_BAR,
+    r: pyct.Real = LINESEARCH_DEFAULT_R,
+    c: pyct.Real = LINESEARCH_DEFAULT_C,
+) -> pyct.Real:
+
+    # document where default values come from (continuous opti course)
+
+    def default_if_none(v, default_v):
+        return v if v is not None else default_v
+
+    a = default_if_none(a_bar, LINESEARCH_DEFAULT_A_BAR)
+    r = default_if_none(r, LINESEARCH_DEFAULT_R)
+    c = default_if_none(c, LINESEARCH_DEFAULT_C)
+
+    f_x = f.apply(x)
+    scalar_prod = c * (g_f_x @ p)
+
+    while f.apply(x + a * p) > f_x + a * scalar_prod:
+        a = r * a
+
+    return a

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -55,6 +55,8 @@ def backtracking_linesearch(
     a: pyct.NDArray
         (..., 1) step sizes.
     """
+    assert 0 < r < 1
+    assert 0 < c < 1
 
     xp = pycu.get_array_module(x)
 
@@ -73,9 +75,12 @@ def backtracking_linesearch(
     if a_bar is None:
         try:
             a_bar = pycrt.coerce(1 / f.diff_lipschitz())
+            assert a_bar > 0, "a_bar: cannot auto-set step size."
         except ZeroDivisionError as exc:
             # f is linear -> line-search unbounded
             raise ValueError("Line-search does not converge for linear functionals.")
+    else:
+        assert a_bar > 0
 
     if gradient is None:
         gradient = f.grad(x)

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -72,6 +72,9 @@ def backtracking_linesearch(
     if gradient is None:
         gradient = f.grad(x)
 
+    f_x = f.apply(x)
+    gradient_times_direction = (gradient * direction).sum(axis=-1, keepdims=True)
+
     def refine(a: pyct.NDArray) -> pyct.NDArray:
         # Do one iteration of the algorithm.
         #
@@ -85,8 +88,8 @@ def backtracking_linesearch(
         # mask : pyct.NDArray[bool]
         #     (..., 1) refinement points
         lhs = f.apply(x + a * direction)
-        rhs1 = f.apply(x)
-        rhs2 = (c * a) * (gradient * direction).sum(axis=-1, keepdims=True)
+        rhs1 = f_x
+        rhs2 = (c * a) * gradient_times_direction
         return lhs > rhs1 + rhs2  # mask
 
     xp = pycu.get_array_module(x)

--- a/src/pycsou/math/linesearch.py
+++ b/src/pycsou/math/linesearch.py
@@ -1,7 +1,7 @@
 import pycsou.abc as pyca
 import pycsou.util.ptype as pyct
 
-LINESEARCH_DEFAULT_A_BAR = 1
+LINESEARCH_DEFAULT_A_BAR = 1.0
 LINESEARCH_DEFAULT_R = 0.5
 LINESEARCH_DEFAULT_C = 10e-4
 
@@ -16,9 +16,28 @@ def backtracking_linesearch(
     c: pyct.Real = LINESEARCH_DEFAULT_C,
 ) -> pyct.Real:
     r"""
-    Backtracking line search algorithm.
+    Backtracking line search algorithm based on the Armijo-Goldstein condition.
+
+    Follow `this link <https://www.wikiwand.com/en/Backtracking_line_search>`_ for reference of the algorithm and
+    default values.
+
+    **Parameterization**
+
+    f: pyca.DiffFunc
+        Differentiable functional
+    x: pyct.NDArray
+        (..., N) initial search position(s)
+    g_f_x: pyct.NDArray
+        (..., N) gradient of `f` at initial search position(s)
+    p: pyct.NDArray
+        (..., N) search direction(s)
+    a_bar: pyct.Real
+        Initial step size, defaults to 1
+    r: pyct.Real
+        Step reduction factor, defaults to 0.5
+    c: pyct:Real
+        Bound reduction factor, defaults to 10e-4
     """
-    # document where default values come from (continuous opti course)
 
     def default_if_none(v, default_v):
         return v if v is not None else default_v

--- a/src/pycsou/opt/solver/__init__.py
+++ b/src/pycsou/opt/solver/__init__.py
@@ -1,3 +1,4 @@
 from pycsou.opt.solver.cg import *
+from pycsou.opt.solver.nlcg import *
 from pycsou.opt.solver.pds import *
 from pycsou.opt.solver.pgd import *

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -116,8 +116,8 @@ class NLCG(pyca.Solver):
         a_k = ls.backtracking_linesearch(
             f=self._f,
             x=x_k,
-            g=g_k,
-            p=p_k,
+            gradient=g_k,
+            direction=p_k,
             a_bar=mst["ls_a_bar"],
             r=mst["ls_r"],
             c=mst["ls_c"],

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -100,7 +100,7 @@ class NLCG(pyca.Solver):
 
         sanitize = lambda _, default: _ if (_ is not None) else default
 
-        mst["x"] = x0 if len(x0.shape) > 1 else x0.reshape(1, x0.shape[0])
+        mst["x"] = x0
         mst["gradient"] = self._f.grad(x0)
         mst["conjugate_dir"] = -mst["gradient"].copy()
         mst["variant"] = self.__parse_variant(variant)

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -155,17 +155,15 @@ class NLCG(pyca.Solver):
 
     def __compute_beta(self, g_f_k: pyct.NDArray, g_f_kp1: pyct.NDArray) -> pyct.Real:
         if self._variant == 0:
-            return (pylinalg.norm(g_f_kp1) / pylinalg.norm(g_f_k)) ** 2
-        return max((g_f_kp1 @ (g_f_kp1 - g_f_k)) / (pylinalg.norm(g_f_k) ** 2), 0.0)
+            return (pylinalg.norm(g_f_kp1, keepdims=True) / pylinalg.norm(g_f_k, keepdims=True)) ** 2
+        return max((g_f_kp1 @ (g_f_kp1 - g_f_k)) / (pylinalg.norm(g_f_k, keepdims=True) ** 2), 0.0)
 
     def __parse_variant(self, variant: str):
         variant = variant.lower()
-        FR_indicator = variant == "FR" or "fletcher" in variant or "reeves" in variant
-        PR_indicator = variant == "PR" or "polak" in variant or "ribi" in variant
+        FR_indicator = variant == "fr"
+        PR_indicator = variant == "pr"
 
-        if FR_indicator and PR_indicator:
-            raise ValueError("The variant was ambiguously specified.")
-        elif FR_indicator:
+        if FR_indicator:
             self._variant = 0
         elif PR_indicator:
             self._variant = 1

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -155,7 +155,6 @@ class NLCG(pyca.Solver):
         x: pyct.NDArray
             (..., N) solution.
         """
-        pycu.compute()
         data, _ = self.stats()
         return data.get("x")
 

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -125,8 +125,8 @@ class NLCG(pyca.Solver):
         # Because NLCG can only generate n conjugate vectors in an n-dimensional space, it makes sense
         # to restart NLCG every n iterations.
         if self._astate["idx"] % mst["restart_rate"] == 0:
-            arrmod = pycu.get_array_module(x_k)
-            beta_kp1 = arrmod.full((1, x_k.shape[-1]), 0.0, dtype=x_k.dtype)
+            xp = pycu.get_array_module(x_k)
+            beta_kp1 = xp.full((1, x_k.shape[-1]), 0.0, dtype=x_k.dtype)
         else:
             beta_kp1 = self.__compute_beta(g_f_k, g_f_kp1)
         p_kp1 = -g_f_kp1 + beta_kp1 * p_k
@@ -163,8 +163,8 @@ class NLCG(pyca.Solver):
         if self._variant == 0:
             return (pylinalg.norm(g_f_kp1, keepdims=True) / pylinalg.norm(g_f_k, keepdims=True)) ** 2
         temp = (g_f_kp1 * (g_f_kp1 - g_f_k)).sum(axis=-1) / (pylinalg.norm(g_f_k, keepdims=True) ** 2)
-        arrmod = pycu.get_array_module(temp)
-        return arrmod.where(temp > 0, temp, 0).T
+        xp = pycu.get_array_module(temp)
+        return xp.where(temp > 0, temp, 0).T
 
     def __parse_variant(self, variant: str):
         variant = variant.lower()

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import pycsou.abc as pyca
 import pycsou.math.linalg as pylinalg
 import pycsou.math.linesearch as ls
@@ -68,7 +70,7 @@ class NLCG(pyca.Solver):
         Number of iterations after which restart is applied.
         By default, restart is done after 'n' iterations, where 'n' corresponds to the dimension of
         the inputs to :math:`f`.
-    a_bar, r, c: pyct.Real
+    a0, r, c: pyct.Real
         Optional line search parameters. (See: :py:mod:`~pycsou.math.linesearch`.)
     """
 
@@ -80,17 +82,27 @@ class NLCG(pyca.Solver):
 
         self._f = f
 
-    @pycrt.enforce_precision(i=("x0", "a_bar", "r", "c"))
+    @pycrt.enforce_precision(i=("x0", "a0", "r", "c"))
     def m_init(
         self,
         x0: pyct.NDArray,
         variant: str = "PR",
         restart_rate: pyct.Integer = None,
-        a_bar: pyct.Real = None,
+        a0: pyct.Real = None,
         r: pyct.Real = None,
         c: pyct.Real = None,
     ):
         mst = self._mstate  # shorthand
+
+        if a0 is None:
+            d_l = self._f.diff_lipschitz()
+            if d_l is np.inf or d_l == 0:
+                raise ValueError(
+                    "Either f gradient's lipschitz constant should be implemented through the diff_lipschitz"
+                    "method or a maximal step size a_bar should be given as an argument to NLCG."
+                )
+            else:
+                a0 = 1.0 / self._f.diff_lipschitz()
 
         if restart_rate is not None:
             assert restart_rate >= 1
@@ -104,10 +116,10 @@ class NLCG(pyca.Solver):
         mst["gradient"] = self._f.grad(x0)
         mst["conjugate_dir"] = -mst["gradient"].copy()
         mst["variant"] = self.__parse_variant(variant)
-        mst["ls_a_bar"] = sanitize(a_bar, ls.LINESEARCH_DEFAULT_A_BAR)
+        mst["ls_a0"] = a0
         mst["ls_r"] = sanitize(r, ls.LINESEARCH_DEFAULT_R)
         mst["ls_c"] = sanitize(c, ls.LINESEARCH_DEFAULT_C)
-        mst["ls_a_k"] = mst["ls_a_bar"]
+        mst["ls_a_k"] = mst["ls_a0"]
 
     def m_step(self):
         mst = self._mstate  # shorthand
@@ -118,7 +130,7 @@ class NLCG(pyca.Solver):
             x=x_k,
             gradient=g_k,
             direction=p_k,
-            a_bar=mst["ls_a_bar"],
+            a0=mst["ls_a0"],
             r=mst["ls_r"],
             c=mst["ls_c"],
         )

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -2,7 +2,7 @@ import pycsou.abc as pyca
 import pycsou.math.linalg as pylinalg
 import pycsou.math.linesearch as ls
 import pycsou.runtime as pycrt
-import pycsou.util.array_module as pyarr
+import pycsou.util as pycu
 import pycsou.util.ptype as pyct
 
 __all__ = [
@@ -131,7 +131,7 @@ class NLCG(pyca.Solver):
         # Because NLCG can only generate n conjugate vectors in an n-dimensional space, it makes sense
         # to restart NLCG every n iterations.
         if self._astate["idx"] % mst["restart_rate"] == 0:
-            arrmod = pyarr.get_array_module(x_k)
+            arrmod = pycu.get_array_module(x_k)
             beta_kp1 = arrmod.full((1, x_k.shape[-1]), 0.0, dtype=x_k.dtype)
         else:
             beta_kp1 = self.__compute_beta(g_f_k, g_f_kp1)
@@ -161,7 +161,7 @@ class NLCG(pyca.Solver):
         x: pyct.NDArray
             (..., N) solution.
         """
-        pyarr.compute()
+        pycu.compute()
         data, _ = self.stats()
         return data.get("x")
 
@@ -169,7 +169,7 @@ class NLCG(pyca.Solver):
         if self._variant == 0:
             return (pylinalg.norm(g_f_kp1, keepdims=True) / pylinalg.norm(g_f_k, keepdims=True)) ** 2
         temp = (g_f_kp1 * (g_f_kp1 - g_f_k)).sum(axis=-1) / (pylinalg.norm(g_f_k, keepdims=True) ** 2)
-        arrmod = pyarr.get_array_module(temp)
+        arrmod = pycu.get_array_module(temp)
         return arrmod.where(temp > 0, temp, 0).T
 
     def __parse_variant(self, variant: str):

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -122,7 +122,7 @@ class NLCG(pyca.Solver):
             r=mst["ls_r"],
             c=mst["ls_c"],
         )
-        x_kp1 = x_k + p_k * a_k[:, None]
+        x_kp1 = x_k + p_k * a_k.reshape((*x_k.shape[:-1], 1))
         g_kp1 = self._f.grad(x_kp1)
 
         # Because NLCG can only generate n conjugate vectors in an n-dimensional space, it makes sense

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -2,7 +2,6 @@ import pycsou.abc as pyca
 import pycsou.math.linalg as pylinalg
 import pycsou.math.linesearch as ls
 import pycsou.runtime as pycrt
-import pycsou.util as pycu
 import pycsou.util.ptype as pyct
 
 __all__ = [

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -85,7 +85,7 @@ class NLCG(pyca.Solver):
     def m_init(
         self,
         x0: pyct.NDArray,
-        variant: str,
+        variant: str = "PR",
         restart_rate: pyct.Integer = None,
         a_bar: pyct.Real = None,
         r: pyct.Real = None,

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -26,36 +26,51 @@ class NLCG(pyca.Solver):
     :math:`\nabla f_k = \nabla f(x_k)` is used as the default stopping criterion.
     By default, the iterations stop when the norm of the gradient is smaller than 1e-4.
 
-    Multiple variants of NLCG exist, that essentially only differ in the weighing of conjugate
-    directions. Two of the most popular variants are offered:
+    Multiple variants of NLCG exist.
+    They differ mainly in how the weights applied to conjugate directions are updated.
+    Two popular variants are implemented:
 
     * The Fletcher-Reeves variant:
 
     .. math::
 
-       \beta_k^\text{FR} = \frac{\Vert{\nabla f_{k+1}}\Vert_2^2}{\Vert{\nabla f_{k}}\Vert_2^2}
+       \beta_k^\text{FR}
+       =
+       \frac{
+         \Vert{\nabla f_{k+1}}\Vert_2^2
+       }{
+         \Vert{\nabla f_{k}}\Vert_2^2
+       }
 
     * The Polak-Ribière+ method:
 
     .. math::
 
-       \beta_k^\text{PR} = \frac{\nabla f_{k+1}^T\left(\nabla f_{k+1} - \nabla f_k\right)}{\Vert{\nabla f_{k}}\Vert_2^2}
-       \beta_k^\text{PR+} = \max\left(0, \beta_k^\text{PR}\right)
+       \beta_k^\text{PR}
+       =
+       \frac{
+         \nabla f_{k+1}^T\left(\nabla f_{k+1} - \nabla f_k\right)
+       }{
+         \Vert{\nabla f_{k}}\Vert_2^2
+       } \\
+       \beta_k^\text{PR+}
+       =
+       \max\left(0, \beta_k^\text{PR}\right)
 
     ``NLCG.fit()`` **Parameterization**
 
     x0: pyct.NDArray
-       (..., N) initial point(s).
+        (..., N) initial point(s).
     variant: str
-       Name of the used variant for NLCG. Use "PR" for the Polak-Ribière+ variant, and "FR" for the
-       Fletcher-Reeves variant.
-    a_bar: pyct.Real
-       Line search optional argument, see: :py:`~pycsou.math.linesearch`.
-    r: pyct.Real
-       Line search optional argument, see: :py:`~pycsou.math.linesearch`.
-    c: pyct.Real
-       Line search optional argument, see: :py:`~pycsou.math.linesearch`.
-
+        Name of the NLCG variant to use.
+        Use "PR" for the Polak-Ribière+ variant.
+        Use "FR" for the Fletcher-Reeves variant.
+    restart_rate: pyct.Integer
+        Number of iterations after which restart is applied.
+        By default, restart is done after 'n' iterations, where 'n' corresponds to the dimension of
+        the inputs to :math:`f`.
+    a_bar, r, c: pyct.Real
+        Optional line search parameters. (See: :py:mod:`~pycsou.math.linesearch`.)
     """
 
     def __init__(self, f: pyca.DiffFunc, **kwargs):

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -60,6 +60,7 @@ class NLCG(pyca.Solver):
        Line search optional argument, see: :py:`~pycsou.math.linesearch`.
     c: pyct.Real
        Line search optional argument, see: :py:`~pycsou.math.linesearch`.
+
     """
 
     def __init__(self, f: pyca.DiffFunc, **kwargs):
@@ -84,9 +85,6 @@ class NLCG(pyca.Solver):
         r: pyct.Real = ls.LINESEARCH_DEFAULT_R,
         c: pyct.Real = ls.LINESEARCH_DEFAULT_C,
     ):
-
-        #  Linesearch arguments are given default values here in order to put them in mathematical state
-
         mst = self._mstate  # shorthand
         self._variant = self.__parse_variant(variant)
         self._ls_a_bar = a_bar

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -116,7 +116,7 @@ class NLCG(pyca.Solver):
         a_k = ls.backtracking_linesearch(
             f=self._f,
             x=x_k,
-            g_f_x=g_k,
+            g=g_k,
             p=p_k,
             a_bar=mst["ls_a_bar"],
             r=mst["ls_r"],

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -87,9 +87,9 @@ class NLCG(pyca.Solver):
         x0: pyct.NDArray,
         variant: str,
         restart_rate: pyct.Integer = None,
-        a_bar: pyct.Real = ls.LINESEARCH_DEFAULT_A_BAR,
-        r: pyct.Real = ls.LINESEARCH_DEFAULT_R,
-        c: pyct.Real = ls.LINESEARCH_DEFAULT_C,
+        a_bar: pyct.Real = None,
+        r: pyct.Real = None,
+        c: pyct.Real = None,
     ):
         mst = self._mstate  # shorthand
 
@@ -99,13 +99,15 @@ class NLCG(pyca.Solver):
         else:
             mst["restart_rate"] = x0.shape[-1]
 
+        sanitize = lambda _, default: _ if (_ is not None) else default
+
         mst["x"] = x0 if len(x0.shape) > 1 else x0.reshape(1, x0.shape[0])
         mst["gradient"] = self._f.grad(x0)
         mst["conjugate_dir"] = -mst["gradient"].copy()
         mst["variant"] = self.__parse_variant(variant)
-        mst["ls_a_bar"] = a_bar  # line-search parameters
-        mst["ls_r"] = r
-        mst["ls_c"] = c
+        mst["ls_a_bar"] = sanitize(a_bar, ls.LINESEARCH_DEFAULT_A_BAR)
+        mst["ls_r"] = sanitize(r, ls.LINESEARCH_DEFAULT_R)
+        mst["ls_c"] = sanitize(c, ls.LINESEARCH_DEFAULT_C)
         mst["ls_a_k"] = mst["ls_a_bar"]
 
     def m_step(self):

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -131,7 +131,12 @@ class NLCG(pyca.Solver):
             r=mst["ls_r"],
             c=mst["ls_c"],
         )
-        x_kp1 = x_k + p_k * a_k
+        # In-place implementation of -----------------
+        #   x_kp1 = x_k + p_k * a_k
+        x_kp1 = p_k.copy()
+        x_kp1 *= a_k
+        x_kp1 += x_k
+        # --------------------------------------------
         g_kp1 = self._f.grad(x_kp1)
 
         # Because NLCG can only generate n conjugate vectors in an n-dimensional space, it makes sense
@@ -140,7 +145,13 @@ class NLCG(pyca.Solver):
             beta_kp1 = pycrt.coerce(0)
         else:
             beta_kp1 = self.__compute_beta(g_k, g_kp1)
-        p_kp1 = -g_kp1 + beta_kp1 * p_k
+
+        # In-place implementation of -----------------
+        #   p_kp1 = -g_kp1 + beta_kp1 * p_k
+        p_kp1 = p_k.copy()
+        p_kp1 *= beta_kp1
+        p_kp1 -= g_kp1
+        # --------------------------------------------
 
         mst["x"], mst["gradient"], mst["conjugate_dir"], mst["ls_a_k"] = x_kp1, g_kp1, p_kp1, a_k
 

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -86,7 +86,7 @@ class NLCG(pyca.Solver):
             assert restart_rate >= 1
             mst["restart_rate"] = int(restart_rate)
         else:
-            mst["restart_rate"] = x0.shape[0]
+            mst["restart_rate"] = x0.shape[-1]
 
         self._variant = self.__parse_variant(variant)
         self._ls_a_bar = a_bar

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -131,7 +131,7 @@ class NLCG(pyca.Solver):
             r=mst["ls_r"],
             c=mst["ls_c"],
         )
-        x_kp1 = x_k + p_k * a_k.reshape((*x_k.shape[:-1], 1))
+        x_kp1 = x_k + p_k * a_k
         g_kp1 = self._f.grad(x_kp1)
 
         # Because NLCG can only generate n conjugate vectors in an n-dimensional space, it makes sense

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -110,14 +110,18 @@ class NLCG(pyca.Solver):
         mst["ls_a_k"] = mst["ls_a_bar"]
 
     def m_step(self):
-
         mst = self._mstate  # shorthand
         x_k, g_k, p_k = mst["x"], mst["gradient"], mst["conjugate_dir"]
 
         a_k = ls.backtracking_linesearch(
-            f=self._f, x=x_k, g_f_x=g_k, p=p_k, a_bar=mst["ls_a_bar"], r=mst["ls_r"], c=mst["ls_c"]
+            f=self._f,
+            x=x_k,
+            g_f_x=g_k,
+            p=p_k,
+            a_bar=mst["ls_a_bar"],
+            r=mst["ls_r"],
+            c=mst["ls_c"],
         )
-
         x_kp1 = x_k + p_k * a_k[:, None]
         g_kp1 = self._f.grad(x_kp1)
 

--- a/src/pycsou/opt/solver/nlcg.py
+++ b/src/pycsou/opt/solver/nlcg.py
@@ -165,14 +165,8 @@ class NLCG(pyca.Solver):
         xp = pycu.get_array_module(temp)
         return xp.where(temp > 0, temp, 0).T
 
-    def __parse_variant(self, variant: str):
-        variant = variant.lower()
-        FR_indicator = variant == "fr"
-        PR_indicator = variant == "pr"
-
-        if FR_indicator:
-            return 0
-        elif PR_indicator:
-            return 1
-        else:
-            raise ValueError("The NLCG variant was incorrectly specified.")
+    def __parse_variant(self, variant: str) -> str:
+        supported_variants = {"fr", "pr"}
+        if (v := variant.lower().strip()) not in supported_variants:
+            raise ValueError(f"Unsupported variant '{variant}'.")
+        return v

--- a/src/pycsou_tests/opt/solver/test_cg.py
+++ b/src/pycsou_tests/opt/solver/test_cg.py
@@ -29,7 +29,13 @@ class TestCG(conftest.SolverT):
             x0=[
                 None,  # let algorithm choose
                 np.full((N,), 3),
-                np.vstack([np.full((1, N), 1), (np.full((1, N), 15))]),  # multiple initial points
+                np.stack(
+                    [
+                        np.full((N,), 1),
+                        np.full((N,), 15),
+                    ],
+                    axis=0,
+                ),  # multiple initial points
             ],
             restart_rate=[None, N, 2 * N],
         )

--- a/src/pycsou_tests/opt/solver/test_cg.py
+++ b/src/pycsou_tests/opt/solver/test_cg.py
@@ -29,7 +29,7 @@ class TestCG(conftest.SolverT):
             x0=[
                 None,  # let algorithm choose
                 np.full((N,), 3),
-                np.full((2, N), 15),  # multiple initial points
+                np.vstack([np.full((1, N), 1), (np.full((1, N), 15))]),  # multiple initial points
             ],
             restart_rate=[None, N, 2 * N],
         )

--- a/src/pycsou_tests/opt/solver/test_nlcg.py
+++ b/src/pycsou_tests/opt/solver/test_nlcg.py
@@ -11,8 +11,7 @@ import pycsou_tests.opt.solver.conftest as conftest
 class TestNLCG(conftest.SolverT):
     @staticmethod
     def spec_data(N: int) -> list[tuple[pyct.SolverC, dict, dict]]:
-        import pycsou.abc.operator as pyop
-        import pycsou.operator.func as pyfunc
+        from pycsou.operator.func import NullFunc, QuadraticFunc
         from pycsou_tests.operator.examples.test_posdefop import PSDConvolution
 
         klass = [
@@ -20,13 +19,9 @@ class TestNLCG(conftest.SolverT):
         ]
         kwargs_init = [
             dict(
-                f=pyfunc.QuadraticFunc(
-                    PSDConvolution(N=N),
-                    pyop.LinFunc((1, N)).from_array(
-                        np.zeros(
-                            N,
-                        )
-                    ),
+                f=QuadraticFunc(
+                    Q=PSDConvolution(N=N),
+                    c=NullFunc(dim=N),
                 )
             ),
         ]

--- a/src/pycsou_tests/opt/solver/test_nlcg.py
+++ b/src/pycsou_tests/opt/solver/test_nlcg.py
@@ -1,0 +1,52 @@
+import itertools
+
+import numpy as np
+import pytest
+
+import pycsou.opt.solver as pycos
+import pycsou.util.ptype as pyct
+import pycsou_tests.opt.solver.conftest as conftest
+
+
+class TestNLCG(conftest.SolverT):
+    @staticmethod
+    def spec_data(N: int) -> list[tuple[pyct.SolverC, dict, dict]]:
+        import pycsou.abc.operator as pyop
+        import pycsou.operator.func as pyfunc
+        from pycsou_tests.operator.examples.test_posdefop import PSDConvolution
+
+        klass = [
+            pycos.NLCG,
+        ]
+        kwargs_init = [
+            dict(
+                f=pyfunc.QuadraticFunc(
+                    PSDConvolution(N=N),
+                    pyop.LinFunc((1, N)).from_array(
+                        np.zeros(
+                            N,
+                        )
+                    ),
+                )
+            ),
+        ]
+
+        kwargs_fit = []
+        param_sweep = dict(
+            x0=[
+                np.full((N,), 3.0),
+                np.full((2, N), 15.0),  # multiple initial points
+            ],
+            variant=["PR", "FR"],
+        )
+        for config in itertools.product(*param_sweep.values()):
+            d = dict(zip(param_sweep.keys(), config))
+            kwargs_fit.append(d)
+
+        data = itertools.product(klass, kwargs_init, kwargs_fit)
+        return list(data)
+
+    @pytest.fixture(params=spec_data(N=7))
+    def spec(self, request) -> tuple[pyct.SolverC, dict, dict]:
+        klass, kwargs_init, kwargs_fit = request.param
+        return klass, kwargs_init, kwargs_fit

--- a/src/pycsou_tests/opt/solver/test_nlcg.py
+++ b/src/pycsou_tests/opt/solver/test_nlcg.py
@@ -37,7 +37,10 @@ class TestNLCG(conftest.SolverT):
                 np.full((N,), 3.0),
                 np.full((2, N), 15.0),  # multiple initial points
             ],
-            variant=["PR", "FR"],
+            variant=[
+                "PR",
+                "FR",
+            ],
         )
         for config in itertools.product(*param_sweep.values()):
             d = dict(zip(param_sweep.keys(), config))


### PR DESCRIPTION
New files are linesearch.py (in pycsou/math) and nclg.py (in pycsou/opt/solver) with an associated test. 

Two variants of NLCG implemented: Poliak-Ribière+ and Fletcher-Reeves, that only differ (like all NLCG variants out there) in the computation of $\beta_n$, more details [here](https://www.wikiwand.com/en/Nonlinear_conjugate_gradient_method).

Possible future improvements: 
- customised linesearch function support to NLCG.
- customised beta_k computation method support to NLCG.