### PR TITLE
V2 dev stencilop

### DIFF
--- a/doc/pycsou.math.rst
+++ b/doc/pycsou.math.rst
@@ -20,6 +20,14 @@ pycsou.math.linesearch module
    :undoc-members:
    :show-inheritance:
 
+pycsou.math.stencil module
+-----------------------------
+
+.. automodule:: pycsou.math.stencil
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/src/pycsou/math/stencil.py
+++ b/src/pycsou/math/stencil.py
@@ -1,0 +1,224 @@
+import string
+import typing as typ
+
+import numba
+import numba.cuda
+import numpy as np
+
+import pycsou.util as pycu
+import pycsou.util.ptype as pyct
+
+
+def make_nd_stencil(coefficients: pyct.NDArray, center: pyct.NDArray) -> typ.Callable:
+    r"""
+    Create a multidimensional Just-In-Time (JIT) compiled stencil from a given set of coefficients.
+
+    The stencil computation is based on Numba's stencils, which work through kernels that look like standard Python
+    function definitions but with different semantics with respect to array indexing. Numba stencils allow clearer,
+    more concise code and enable higher performance through parallelization of the stencil execution (see
+    `Numba stencils <https://numba.pydata.org/numba-doc/latest/user/stencil.html>`_ for further reference).
+
+    Parameters
+    ----------
+    coefficients: NDArray
+        Kernel coefficients. Must have the same number of dimensions as the input array's shape (without the
+        stacking dimensions).
+
+    center: NDArray
+        Index of the kernel's center. Must be a 1-dimensional array with one element per dimension in ``coefficients``.
+
+    Returns
+    -------
+    stencil
+        JIT-ted stencil.
+
+    Examples
+    ________
+    .. code-block:: python3
+
+        import dask.array as da
+        import numpy as np
+
+        from pycsou.math.stencil import make_nd_stencil
+
+        D = np.array([[1, 0, 1], [1, 0, 1], [1, 0, 1]])
+        center = np.array([1, 1])
+
+        # NUMPY
+        img = np.random.normal(0, 10, size=(1000, 100, 100))
+        stencil = make_nd_stencil(D, center)
+        out = stencil(img)
+
+        # BOUNDARY CONDITIONS DASK
+        depth_post = D.shape - center - 1
+        depth_pre = center
+        depth = {0: 0}
+        depth.update({i + 1: (depth_pre[i], depth_post[i]) for i in range(D.ndim)})
+        boundary = {i: "none" for i in range(D.ndim + 1)}
+
+        # DASK
+        img_da = da.asarray(img, chunks=(100, 10, 10))
+        out_da = img_da.map_overlap(stencil, depth=depth, boundary=boundary, dtype=D.dtype)
+
+        # Need to handle equally the borders
+        print(np.allclose(out[1:-1, 1:-1, 1:-1], out_da.compute()[1:-1, 1:-1, 1:-1]))
+
+    See also
+    ________
+    :py:func:`~pycsou.math.stencil.make_nd_stencil_gpu`
+    :py:class:`~pycsou.operator.linop.base._StencilOp
+    """
+
+    indices = np.indices(coefficients.shape).reshape(coefficients.ndim, -1).T - center[None, ...]
+    coefficients = pycu.compute(coefficients).ravel()
+    kernel_string = _create_kernel_string(coefficients, indices)
+    exec(_stencil_string.substitute(kernel=kernel_string, dtype=coefficients.dtype), globals())
+    return my_stencil
+
+
+def make_nd_stencil_gpu(coefficients: pyct.NDArray, center: pyct.NDArray, func_name: str) -> typ.Callable:
+    r"""
+    Create a multidimensional Just-In-Time (JIT) compiled GPU stencil from a given set of coefficients.
+
+    Numba supports a JIT compilation of stencil computations (see :py:func:`~pycsou.math.stencil.make_nd_stencil`)
+    with CUDA on compatible GPU devices.
+
+    Parameters
+    ----------
+    coefficients: NDArray
+        Kernel coefficients. Must have the same number of dimensions as the input array's shape (without the
+        stacking dimensions).
+
+    center: NDArray
+        Index of the kernel's center. Must be a 1-dimensional array with one element per dimension in ``coefficients``.
+
+    Returns
+    -------
+    gpu-stencil
+        JIT-ted CUDA kernel
+
+    Examples
+    ________
+    .. code-block:: python3
+
+        import cupy as cp
+        import numpy as np
+
+        from pycsou.math.stencil import make_nd_stencil, make_nd_stencil_gpu
+
+        D = np.array([[1, 0, 1], [1, 0, 1], [1, 0, 1]])
+        center = np.array([1, 1])
+
+        # NUMPY
+        img = np.random.normal(0, 10, size=(1000, 100, 100))
+        stencil = make_nd_stencil(D, center)
+        out = stencil(img)
+
+
+
+        # CUPY
+        img_cp = cp.asarray(img)
+        stencil_cp = make_nd_stencil_gpu(cp.asarray(D), center)
+        out_cp = cp.zeros_like(img_cp)
+        threadsperblock = (10, 10, 10)
+        blockspergrid_x = math.ceil(img_cp.shape[0] / threadsperblock[0])
+        blockspergrid_y = math.ceil(img_cp.shape[1] / threadsperblock[1])
+        blockspergrid_z = math.ceil(img_cp.shape[2] / threadsperblock[2])
+        blockspergrid = (blockspergrid_x, blockspergrid_y, blockspergrid_z)
+        stencil_cp[blockspergrid, threadsperblock](img_cp, out_cp)
+        print(np.allclose(out[1:-1, 1:-1, 1:-1], out_cp.get()[1:-1, 1:-1, 1:-1]))
+        print("Done")
+
+    See also
+    ________
+    :py:func:`~pycsou.math.stencil.make_nd_stencil`
+    :py:class:`~pycsou.operator.linop.base._StencilOp`
+
+    """
+    # If kernel is 3D, then the computation has to loop over samples (numba cuda grid can have at maximum 3 dimensions)
+    if coefficients.ndim > 3:
+        raise ValueError("The Stencil operator does not support GPU kernels with more than 3D dims.")
+
+    stacking_dim = 1 if coefficients.ndim < 3 else 0
+    letters1 = list(string.ascii_lowercase)[: coefficients.ndim + stacking_dim]
+    letters2 = list(string.ascii_lowercase)[coefficients.ndim + stacking_dim : 2 * (coefficients.ndim + stacking_dim)]
+
+    indices = np.indices(coefficients.shape).reshape(coefficients.ndim, -1).T - center
+    kernel_string = _create_kernel_string_gpu(letters1, coefficients.ravel(), indices, stacking_dim)
+    if_statement = _create_if_statement_gpu(letters1, letters2, indices, coefficients, stacking_dim)
+
+    exec(
+        _stencil_string_gpu.substitute(
+            func_name=func_name,
+            letters1=", ".join(letters1),
+            letters2=", ".join(letters2),
+            len_letters=str(len(letters1)),
+            if_statement=if_statement,
+            kernel=kernel_string,
+            dtype=f"{coefficients.dtype}["
+            + ",".join(
+                [
+                    ":",
+                ]
+                * (coefficients.ndim + stacking_dim)
+            )
+            + "]",
+        ),
+        globals(),
+    )
+    return globals()[f"kernel_cupy_{func_name}"]
+
+
+def _create_kernel_string(coefficients: pyct.NDArray, indices: pyct.NDArray) -> str:
+    return " + ".join(
+        [
+            f"a[0, {', '.join([str(elem) for elem in ids_])}] * np.{coefficients.dtype}({str(coefficients[i])})"
+            for i, ids_ in enumerate(indices)
+        ]
+    )
+
+
+def _create_kernel_string_gpu(letters1: typ.List, coefficients: pyct.NDArray, indices: pyct.NDArray, stacking_dim: int):
+    stacking_str = f"{letters1[0]}, " if stacking_dim else ""
+    return f" + ".join(
+        [
+            f"arr[{stacking_str}{', '.join(['+'.join([letters1[e + stacking_dim], str(elem)]) for e, elem in enumerate(ids_)])}] * cp.{coefficients.dtype}({str(coefficients[i])})"
+            for i, ids_ in enumerate(indices)
+        ]
+    )
+
+
+def _create_if_statement_gpu(
+    letters1: typ.List, letters2: typ.List, indices: pyct.NDArray, coefficients: pyct.NDArray, stacking_dim: int
+):
+    stacking_str = f"(0 <= {letters1[0]} < {letters2[0]}) and " if stacking_dim else ""
+    return stacking_str + " and ".join(
+        [
+            f"({-np.min(indices, axis=0)[i]} <= {letters1[i + stacking_dim]} < ({letters2[i+ stacking_dim]} - {np.max(indices, axis=0)[i]}))"
+            for i in range(coefficients.ndim)
+        ]
+    )
+
+
+# Cache cannot be used with string defined functions (see https://github.com/numba/numba/issues/3501 for workaround)
+_stencil_string = string.Template(
+    r"""
+@numba.njit(parallel=True, fastmath=True, nogil=True)
+def my_stencil(arr):
+    stencil = numba.stencil(
+    lambda a: ${kernel},
+    signature=["${dtype}(${dtype})"]
+    )(arr)
+    return stencil"""
+)
+_stencil_string_gpu = string.Template(
+    r"""
+import cupy as cp
+#@numba.cuda.jit('void(${dtype},${dtype})') # fails for float32
+@numba.cuda.jit
+def kernel_cupy_${func_name}(arr, out):
+    $letters1 = numba.cuda.grid(${len_letters}) # j, k
+    $letters2 = arr.shape # n, m
+    if $if_statement:
+        out[$letters1] = ${kernel}"""
+)

--- a/src/pycsou/operator/linop/base.py
+++ b/src/pycsou/operator/linop/base.py
@@ -1,3 +1,4 @@
+import math
 import types
 import typing as typ
 import warnings
@@ -7,6 +8,7 @@ import scipy.sparse as sp
 import sparse as ssp
 
 import pycsou.abc as pyca
+import pycsou.math.stencil as pycstencil
 import pycsou.runtime as pycrt
 import pycsou.util as pycu
 import pycsou.util.deps as pycd
@@ -589,3 +591,322 @@ def Sum(arg_shape, axis=None) -> pyct.OpT:
     op._name = "Sum"
 
     return op
+
+
+class _StencilOp(pyca.SquareOp):
+    r"""
+    Base class for NDArray computing functions that operate only on a local region of the NDArray through a
+    multidimensional kernel, namely through correlation and convolution.
+
+    This class leverages the :py:func:`numba.stencil` decorator, which allows to JIT (Just-In-Time) compile these
+    functions to run more quickly.
+
+    Parameters
+    ----------
+    stencil_coefs: NDArray
+        Stencil coefficients. Must have the same number of dimensions as the input array's arg_shape (i.e., without the
+        stacking dimension).
+    center: NDArray
+        Index of the kernel's center. Must be a 1-dimensional array with one element per dimension in ``stencil_coefs``.
+    arg_shape: tuple
+        Shape of the input array.
+    enable_warnings: bool
+        If ``True``, emit a warning in case of precision mismatch issues.
+
+
+    Examples
+    --------
+
+    The following example creates a Stencil operator based on a 2-dimensional kernel. It shows how to perform correlation
+    and convolution in CPU, GPU (Cupy) and distributed across different cores (Dask).
+
+    .. code-block:: python3
+
+       from pycsou.operator.linop.base import StencilOp
+       import numpy as np
+       import cupy as cp
+       import dask.array as da
+
+       nsamples = 2
+       data_shape = (500, 100)
+       da_blocks = (50, 10)
+
+       # Numpy
+       data = np.ones((nsamples, *data_shape)).reshape(nsamples, -1)
+       # Cupy
+       data_cu = cp.ones((nsamples, *data_shape)).reshape(nsamples, -1)
+       # Dask
+       data_da = da.from_array(data, chunks=da_blocks).reshape(nsamples, -1)
+
+       kernel = np.array([[0.5, 0.0, 0.5],
+                          [0.0, 0.0, 0.0],
+                          [0.5, 0.0, 0.5]])
+
+       center = np.array([1, 0])
+
+       stencil = StencilOp(stencil_coefs=kernel, center=center, arg_shape=data_shape, boundary=0.)
+       stencil_cu = StencilOp(stencil_coefs=cp.asarray(kernel), center=center, arg_shape=data_shape, boundary=0.)
+
+       # Correlate images with kernels
+       out = stencil(data).reshape(nsamples, *data_shape)
+       out_da = stencil(data_da).reshape(nsamples, *data_shape).compute()
+       out_cu = stencil_cu(data_cu).reshape(nsamples, *data_shape).get()
+
+       # Convolve images with kernels
+       out_adj = stencil.adjoint(data).reshape(nsamples, *data_shape)
+       out_da_adj = stencil.adjoint(data_da).reshape(nsamples, *data_shape).compute()
+       out_cu_adj = stencil_cu.adjoint(data_cu).reshape(nsamples, *data_shape).get()
+
+    Notes
+    -----
+
+    Note that to perform stencil operations on GPU NDArrays, the stencil has to be instantiated with GPU kernel
+    coefficients.
+
+    - **Remark 1**. The :py:class:`~pycsou.operator.linop.base.StencilOp` class allows to perform both correlation and convolution. By
+    default, the ``apply`` method will perform **correlation** of the input array with the given kernel / stencil,
+    whereas the ``adjoint`` method will perform **convolution**.
+
+    - **Remark 2**. When instantiated with a multidimensional kernel, the :py:class:`~pycsou.operator.linop.base.StencilOp` performs
+    convolution and correlation operations as non-separable filters. When possible, the user can decide whether to
+    separate the filtering operation by composing different stencils for different axis to accelerate performance. This
+    approach is not guaranteed to improve performance due to the repeated copying of arrays associated to internal
+    padding operations.
+
+    - **Remark 3**. The stencil computation is only performed on those parts of the input array in which the kernel
+    finds support. Padding is recommended to guarantee that the stencil computation is performed on all the input
+    elements (see :py:class:~pycsou.operator.linop.PadOp`.)
+
+    - **Remark 4*. By default, for GPU computing, the ``threadsperblock`` argument is set according to the following criteria:
+
+        - Number of the  GPU's threads per block (:math:`c`), i.e.,:
+           .. math::
+
+               \prod_{i=0}^{D-1} t_{i} \leq c
+
+           where :math:`t_{i}` is the number of threads per block in dimension :math:`i`, :math:`D` is the number of dimensions
+           of the kernel.
+
+        - Maximum number of contiguous threads as possible:
+
+           Because arrays are stored in row-major order, a larger number of threads per block in the last axis of the Cupy
+           array benefits the spatial locality in memory caching. For this reason ``threadsperblock`` is set to the maximum
+           number in the last axis, and to the minimum possible (respecting the kernel shape) in the other axes.
+
+           .. math::
+
+               t_{i} = 2^{j} \leq k_{i}, s.t., 2^{j+1} > k_{i} \quad \textrm{for} \quad i\in[0, \dots, D-2],
+
+    .. warning::
+
+       The adjoint method is not correct unless padding of the input array is performed. This is a private class and not
+       meant for using without composition with the PadOp.
+
+       Due to code compilation the stencil methods assume arrays are in row-major or C order. If the input array is in
+       Fortran or F order, a copy in C order is created automatically, which can lead to increased time and memory
+       usage.
+    """
+
+    def __init__(
+        self,
+        stencil_coefs: pyct.NDArray,
+        center: pyct.NDArray,
+        arg_shape: pyct.OpShape,
+        enable_warnings: bool = True,
+    ):
+        size = np.prod(arg_shape).item()
+
+        super().__init__((size, size))
+
+        self.arg_shape = arg_shape
+        self.ndim = len(arg_shape)
+        self._sanitize_inputs(stencil_coefs, center)
+        self._make_stencils(self.stencil_coefs)
+        self._lipschitz = 2 * abs(self.stencil_coefs).max()
+        self._enable_warnings = bool(enable_warnings)
+
+    @pycrt.enforce_precision(i="arr", o=True)
+    def apply(self, arr: pyct.NDArray) -> pyct.NDArray:
+        r"""
+        Parameters
+        ----------
+        arr: NDArray
+            Array to be correlated with the kernel.
+
+        Returns
+        -------
+        out: NDArray
+            NDArray with same shape as the input NDArray, correlated with kernel.
+        """
+        if (arr.dtype != self.stencil_coefs.dtype) and self._enable_warnings:
+            msg = "Computation may not be performed at the requested precision."
+            warnings.warn(msg, pycuw.PrecisionWarning)
+
+        return self._apply_dispatch(arr)
+
+    @pycrt.enforce_precision(i="arr", o=True)
+    def adjoint(self, arr: pyct.NDArray) -> pyct.NDArray:
+        r"""
+        Parameters
+        ----------
+        arr: NDArray
+            Array to be convolved with the kernel.
+
+        Returns
+        -------
+        out: NDArray
+            NDArray with same shape as the input NDArray, convolved with kernel.
+        """
+        if (arr.dtype != self.stencil_coefs.dtype) and self._enable_warnings:
+            msg = "Computation may not be performed at the requested precision."
+            warnings.warn(msg, pycuw.PrecisionWarning)
+
+        return self._adjoint_dispatch(arr)
+
+    def asarray(self, **kwargs) -> pyct.NDArray:
+        r"""
+        Make a matrix representation of the stencil operator.
+        """
+        dtype = kwargs.pop("dtype", pycrt.getPrecision().value)
+        xp = kwargs.pop("xp", pycd.NDArrayInfo.NUMPY.module())
+        dtype_ = self.stencil_coefs.dtype
+        xp_ = pycu.get_array_module(self.stencil_coefs)
+
+        E = xp_.eye(self.dim, dtype=dtype_)
+        A = self.apply(E).T
+        A = pycu.to_NUMPY(A) if xp_.__name__ == "cupy" and xp.__name__ != "cupy" else A
+        return xp.array(A, dtype=dtype)
+
+    def lipschitz(self, **kwargs) -> pyct.Real:
+        r"""
+        Compute a Lipschitz constant of the stencil operator.
+        """
+        N = pycd.NDArrayInfo
+        info = N.from_obj(self.stencil_coefs)
+        kwargs.update(
+            xp=info.module(),
+            gpu=info == N.CUPY,
+        )
+        return super().lipschitz(**kwargs)
+
+    def _apply(self, arr: pyct.NDArray) -> pyct.NDArray:
+        return self.stencil(arr.reshape(-1, *self.arg_shape)).reshape(*arr.shape)
+
+    def _apply_dask(self, arr: pyct.NDArray) -> pyct.NDArray:
+        return (
+            arr.reshape(-1, *self.arg_shape)
+            .map_overlap(self.stencil, depth=self.width, dtype=arr.dtype)
+            .reshape(arr.shape)
+        )
+
+    def _apply_cupy(self, arr: pyct.NDArray) -> pyct.NDArray:
+        xp = pycu.get_array_module(arr)
+        arr_shape = arr.shape
+        arr = arr.reshape(-1, *self.arg_shape)
+        out = xp.zeros_like(arr)
+        # Cuda grid cannot have more than 3D. In the case of arg_shape with 3D, the cuda grid loops across the 3D and
+        # looping over stacking dimension is done within the following Python list comprehension.
+        tbp, bpg = self._get_gpu_config(arr)
+        self.stencil[bpg, tbp](arr, out) if len(self.arg_shape) < 3 else [
+            self.stencil[bpg, tbp](arr[i], out[i]) for i in range(arr.shape[0])
+        ]
+        return out.reshape(arr_shape)
+
+    def _adjoint(self, arr: pyct.NDArray) -> pyct.NDArray:
+        return self.stencil_adjoint(arr.reshape(-1, *self.arg_shape)).reshape(arr.shape)
+
+    def _adjoint_dask(self, arr: pyct.NDArray) -> pyct.NDArray:
+        return (
+            arr.reshape(-1, *self.arg_shape)
+            .map_overlap(
+                self.stencil_adjoint,
+                depth=self.width,
+                dtype=arr.dtype,
+            )
+            .reshape(arr.shape)
+        )
+
+    def _adjoint_cupy(self, arr: pyct.NDArray) -> pyct.NDArray:
+        xp = pycu.get_array_module(arr)
+        arr_shape = arr.shape
+        arr = arr.reshape(-1, *self.arg_shape)
+        out = xp.zeros_like(arr)
+        tbp, bpg = self._get_gpu_config(arr)
+        self.stencil_adjoint[bpg, tbp](arr, out) if len(self.arg_shape) < 3 else [
+            self.stencil_adjoint[bpg, tbp](arr[i], out[i]) for i in range(arr.shape[0])
+        ]
+        return out.reshape(arr_shape)
+
+    @pycu.redirect("arr", DASK=_apply_dask, CUPY=_apply_cupy)
+    def _apply_dispatch(self, arr: pyct.NDArray) -> pyct.NDArray:
+        return self._apply(arr)
+
+    @pycu.redirect("arr", DASK=_adjoint_dask, CUPY=_adjoint_cupy)
+    def _adjoint_dispatch(self, arr: pyct.NDArray) -> pyct.NDArray:
+        return self._adjoint(arr)
+
+    def _make_stencils_cpu(self, stencil_coefs: pyct.NDArray, **kwargs) -> None:
+        # Create numba JIT-ted stencil functions for apply and adjoint methods.
+        self.stencil = pycstencil.make_nd_stencil(coefficients=self.stencil_coefs, center=self.center)
+        self.stencil_adjoint = pycstencil.make_nd_stencil(
+            coefficients=self.stencil_coefs_adjoint, center=self.center_adjoint
+        )
+
+    def _make_stencils_gpu(self, stencil_coefs: pyct.NDArray, **kwargs) -> None:
+        # Create numba.cuda JIT-ted functions for apply and adjoint methods.
+        self.stencil = pycstencil.make_nd_stencil_gpu(
+            coefficients=self.stencil_coefs, center=self.center, func_name="apply"
+        )
+        self.stencil_adjoint = pycstencil.make_nd_stencil_gpu(
+            coefficients=self.stencil_coefs_adjoint, center=self.center_adjoint, func_name="adjoint"
+        )
+
+    @pycu.redirect("stencil_coefs", CUPY=_make_stencils_gpu)
+    def _make_stencils(self, stencil_coefs: pyct.NDArray) -> None:
+        self._make_stencils_cpu(stencil_coefs)
+
+    def _sanitize_inputs(self, stencil_coefs: pyct.NDArray, center: pyct.NDArray):
+        # Check that inputs have the correct shape and correctly handle the boundary conditions.
+        assert len(center) == stencil_coefs.ndim == self.ndim, (
+            "The stencil coefficients should have the same"
+            " number of dimensions as `arg_shape` and the "
+            "same length as `center`."
+        )
+        self.xp = xp = pycu.get_array_module(stencil_coefs)
+        self.stencil_coefs = stencil_coefs
+        self.center = self.center_dask = np.atleast_1d(center)
+        self.stencil_coefs_adjoint = xp.flip(stencil_coefs)
+        self.center_adjoint = np.array(stencil_coefs.shape) - 1 - np.atleast_1d(center)
+        self.width = self._set_width(stencil_coefs.ndim)
+
+    def _set_width(self, ndim):
+        # set appropriate padding depth for different backends
+        depth_right = np.atleast_1d(self.stencil_coefs.shape) - self.center - 1
+        return tuple([(0, 0)] + [(self.center[i].item(), depth_right[i].item()) for i in range(ndim)])
+
+    def _get_gpu_config(self, arr):
+        # Get max number of threads in device
+        t_max = arr.device.attributes["MaxThreadsPerBlock"]
+        # Set at least as many threads as kernel elements per dimension
+        _next_power_of_2 = lambda x: 1 if x == 0 else 2 ** (x - 1).bit_length()
+        kernel_shape = self.stencil_coefs.shape
+        tpb = [int(_next_power_of_2(kernel_shape[d])) for d in range(len(kernel_shape))]
+        # Set maximum number of threads in the row-major order
+        tpb[-1] = int(t_max / (np.prod(tpb) / tpb[-1]))
+        # If kernel has less than 3D, add stacking dimension
+        if len(self.arg_shape) < 3:
+            tpb = [1] + tpb
+        # If nthreads larger than a given array dimension size, use threads in other dimensions
+        # This maximizes locality of cached memory (row-major order) to improve performance
+        for i in range(len(tpb) - 1, -1, -1):
+            while tpb[i] > self.arg_shape[i - 1] + np.sum(self.width[i]):
+                tpb[i] = int(tpb[i] / 2)
+                if i > 0:
+                    tpb[i - 1] = int(tpb[i - 1] * 2)
+
+        threadsperblock = tuple(tpb)
+
+        # Define blockspergrid based on input array shape and threadsperblock
+        aux_stacking = 0 if len(self.arg_shape) < 3 else 1
+        blockspergrid = tuple([math.ceil(arr.shape[i + aux_stacking] / tpb) for i, tpb in enumerate(threadsperblock)])
+        return threadsperblock, blockspergrid

--- a/src/pycsou_tests/operator/linop/base/test_stencilop.py
+++ b/src/pycsou_tests/operator/linop/base/test_stencilop.py
@@ -1,0 +1,213 @@
+import itertools
+
+import numpy as np
+import numpy.linalg as npl
+import pytest
+import scipy.ndimage as scimage
+
+import pycsou.operator as pycob
+import pycsou.runtime as pycrt
+import pycsou.util as pycu
+import pycsou.util.deps as pycd
+import pycsou.util.ptype as pyct
+import pycsou_tests.operator.conftest as conftest
+
+if pycd.CUPY_ENABLED:
+    import cupy.linalg as cpl
+
+import collections.abc as cabc
+
+
+# We disable PrecisionWarnings since Stencil() is not precision-agnostic, but the outputs
+# computed must still be valid. We also disable NumbaPerformanceWarnings, as these appear
+# due to using the overkill use of GPU for very small test input arrays.
+@pytest.mark.filterwarnings(
+    "ignore::pycsou.util.warning.PrecisionWarning", "ignore::numba.core.errors.NumbaPerformanceWarning"
+)
+class TestStencil(conftest.LinOpT):
+    @pytest.fixture(
+        params=itertools.product(
+            [2], [0]  # (1) 1D and (3) 3D kernels  # [0, 2]  # right or left centered kernels (wrt origin=1)
+        )
+    )
+    def stencil_params(self, request):
+        ndim, pos = request.param
+        stencil_coefs = np.expand_dims(self._random_array((2,), seed=20), axis=list(np.arange(ndim - 1)))
+        center = np.zeros(ndim, dtype=int)
+        center[-1] = pos
+        return stencil_coefs, center
+
+    @pytest.fixture
+    def stencil_coefs(self, stencil_params):
+        return stencil_params[0]
+
+    @pytest.fixture
+    def center(self, stencil_params):
+        return stencil_params[1]
+
+    @pytest.fixture
+    def arg_shape(self, stencil_params):
+        return (8,) * stencil_params[0].ndim
+
+    @pytest.fixture(params=pycd.NDArrayInfo)
+    def ndi(self, request):
+        return request.param
+
+    @pytest.fixture(params=pycrt.Width)
+    def width(self, request):
+        return request.param
+
+    @pytest.fixture
+    def spec(
+        self,
+        stencil_coefs,
+        center,
+        arg_shape,
+        ndi,
+        width,
+    ) -> tuple[pyct.OpT, pycd.NDArrayInfo, pycrt.Width]:
+        op = pycob.linop.base._StencilOp(
+            stencil_coefs=ndi.module().asarray(stencil_coefs, dtype=width.value),
+            center=center,
+            arg_shape=arg_shape,
+        )
+        return op, ndi, width
+
+    @pytest.fixture
+    def data_apply(self, op, arg_shape) -> conftest.DataLike:
+        arr = self._random_array(((arg_shape[0] - 4) ** len(arg_shape),), seed=20)  # random seed for reproducibility
+        arr = np.pad(arr.reshape(*[s - 4 for s in arg_shape]), ((2, 2),) * len(arg_shape), constant_values=0.0).ravel()
+        kernel, center = op.stencil_coefs, op.center
+        xp = pycu.get_array_module(kernel)
+        kernel = kernel.get() if xp.__name__ == "cupy" else kernel
+
+        origin = [
+            0,
+        ] + list(center)
+        origin[-1] -= 1
+
+        out = scimage.correlate(
+            arr.reshape(-1, *op.arg_shape),
+            kernel.reshape(1, *kernel.shape),
+            origin=origin,
+            mode="constant",
+            cval=np.nan,
+        )
+        out[np.isnan(out)] = 0
+
+        return dict(
+            in_=dict(arr=arr),
+            out=out.ravel(),
+        )
+
+    @pytest.fixture
+    def data_adjoint(self, op, arg_shape) -> conftest.DataLike:
+        arr = self._random_array(((arg_shape[0] - 4) ** len(arg_shape),), seed=20)  # random seed for reproducibility
+        arr = np.pad(arr.reshape(*[s - 4 for s in arg_shape]), ((2, 2),) * len(arg_shape), constant_values=0.0).ravel()
+
+        out = (op.asarray().T @ arr.T).T
+
+        return dict(
+            in_=dict(arr=arr),
+            out=out.ravel(),
+        )
+
+    @pytest.fixture
+    def data_shape(self, arg_shape) -> pyct.OpShape:
+        size = np.prod(arg_shape).item()
+        sh = (size, size)
+        return sh
+
+    @pytest.fixture
+    def data_pinv(self, op, _damp, data_apply):
+
+        arr = data_apply["out"]
+        xp = pycu.get_array_module(arr)
+        xpl = cpl if xp.__name__ == "cupy" else npl
+
+        B = op.asarray(xp=xp, dtype=pycrt.Width.DOUBLE.value)
+        A = B.T @ B
+        # -------------------------------------------------
+        for i in range(op.dim):
+            A[i, i] += _damp
+
+        out, *_ = xpl.lstsq(A, B.T @ arr)
+        data = dict(
+            in_=dict(
+                arr=arr,
+                damp=_damp,
+                kwargs_init=dict(),
+                kwargs_fit=dict(),
+            ),
+            out=out,
+        )
+        return data
+
+    @pytest.fixture
+    def data_pinvT(self, op, _damp, data_apply):
+        arr = data_apply["in_"]["arr"]
+        xp = pycu.get_array_module(arr)
+        xpl = cpl if xp.__name__ == "cupy" else npl
+        B = op.asarray(xp=xp, dtype=pycrt.Width.DOUBLE.value)
+        A = B.T @ B
+        # -------------------------------------------------
+        for i in range(op.dim):
+            A[i, i] += _damp
+
+        out, *_ = xpl.lstsq(A, arr)
+        out = B @ out
+        data = dict(
+            in_=dict(
+                arr=arr,
+                damp=_damp,
+                kwargs_init=dict(),
+                kwargs_fit=dict(),
+            ),
+            out=out,
+        )
+        return data
+
+    @pytest.fixture
+    def data_math_lipschitz(self, op) -> cabc.Collection[np.ndarray]:
+        N_test = 5
+        shape = (N_test,) + ((op.arg_shape[0] - 4) ** len(op.arg_shape),)
+        x = self._random_array(shape)
+        x = np.pad(
+            x.reshape(N_test, *[s - 4 for s in op.arg_shape]),
+            ((0, 0),) + ((2, 2),) * len(op.arg_shape),
+            constant_values=0.0,
+        ).reshape(N_test, -1)
+        return x
+
+    @pytest.fixture
+    def data_math_diff_lipschitz(self, op) -> cabc.Collection[np.ndarray]:
+        N_test = 5
+        shape = (N_test,) + ((op.arg_shape[0] - 4) ** len(op.arg_shape),)
+        x = self._random_array(shape)
+        x = np.pad(
+            x.reshape(N_test, *[s - 4 for s in op.arg_shape]),
+            ((0, 0),) + ((2, 2),) * len(op.arg_shape),
+            constant_values=0.0,
+        ).reshape(N_test, -1)
+        return x
+
+    def test_math_adjoint(self, op, xp, width):
+        # Added zero-padding (wrt conftest)
+        self._skip_if_disabled()
+        N = 20
+        shape = (N,) + ((op.arg_shape[0] - 4) ** len(op.arg_shape),)
+        x = self._random_array(shape, xp=xp, width=width)
+        x = np.pad(
+            x.reshape(N, *[s - 4 for s in op.arg_shape]), ((0, 0),) + ((2, 2),) * len(op.arg_shape), constant_values=0.0
+        ).ravel()
+
+        y = self._random_array(shape, xp=xp, width=width)
+        y = np.pad(
+            y.reshape(N, *[s - 4 for s in op.arg_shape]), ((0, 0),) + ((2, 2),) * len(op.arg_shape), constant_values=0.0
+        ).ravel()
+
+        ip = lambda a, b: (a * b).sum(axis=-1)  # (N, Q) * (N, Q) -> (N,)
+        lhs = ip(op.adjoint(x), y)
+        rhs = ip(x, op.apply(y))
+
+        assert conftest.allclose(lhs, rhs, as_dtype=width.value)


### PR DESCRIPTION
Add functionality for Numba JIT-ted stencils, including: 
 - `pycsou.math.stencil`: stencil definition based on f-strings
 - `pycsou.operator.linop.base._StencilOp`: linear operator 
 - `pycsou_tests.operator.linop.base.TestStencil`.