### PR TITLE
[prox_adam] Added Proximal Adam solver

### DIFF
--- a/doc/pycsou.opt.solver.rst
+++ b/doc/pycsou.opt.solver.rst
@@ -12,6 +12,14 @@ pycsou.opt.solver.pgd module
    :undoc-members:
    :show-inheritance:
 
+pycsou.opt.solver.prox_adam module
+----------------------------------
+
+.. automodule:: pycsou.opt.solver.prox_adam
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pycsou.opt.solver.cg module
 ---------------------------
 
@@ -24,14 +32,6 @@ pycsou.opt.solver.nlcg module
 -----------------------------
 
 .. automodule:: pycsou.opt.solver.nlcg
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-pycsou.opt.solver.prox_adam module
-----------------------------------
-
-.. automodule:: pycsou.opt.solver.prox_adam
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/pycsou.opt.solver.rst
+++ b/doc/pycsou.opt.solver.rst
@@ -28,6 +28,14 @@ pycsou.opt.solver.nlcg module
    :undoc-members:
    :show-inheritance:
 
+pycsou.opt.solver.prox_adam module
+----------------------------------
+
+.. automodule:: pycsou.opt.solver.prox_adam
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pycsou.opt.solver.pds module
 ----------------------------
 

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -1,6 +1,7 @@
 References
 ==========
 
+.. [ProxAdam] Melchior, Joseph, Moolekamp. "Proximal Adam: Robust Adaptive Update Scheme for Constrained Optimization" (2020).
 .. [ProxAlg] Parikh, Neal, and Stephen Boyd. "Proximal algorithms." Foundations and Trends in optimization 1.3 (2014): 127-239.
 .. [FirstOrd] Beck, Amir. First-order methods in optimization. Society for Industrial and Applied Mathematics, 2017.
 .. [OnKerLearn] Martins, André FT, et al. "Online multiple kernel learning for structured prediction." arXiv preprint arXiv:1010.2770 (2010).

--- a/src/pycsou/opt/solver/__init__.py
+++ b/src/pycsou/opt/solver/__init__.py
@@ -2,3 +2,4 @@ from pycsou.opt.solver.cg import *
 from pycsou.opt.solver.nlcg import *
 from pycsou.opt.solver.pds import *
 from pycsou.opt.solver.pgd import *
+from pycsou.opt.solver.prox_adam import *

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -202,15 +202,15 @@ class ProxAdam(pyca.Solver):
         self._g = g
 
     @pycrt.enforce_precision(i=("x0", "a", "b1", "b2", "m0", "v0", "p", "eps"))
-    def m_init(
+    def m_init(  # default values from https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.
         self,
         x0: pyct.NDArray,
         variant: str = "adam",
         a: pyct.Real = None,
-        b1: pyct.Real = 0.9,  # default values from:
-        b2: pyct.Real = 0.999,  # https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.
-        m0: pyct.NDArray = None,  # warm start for mean
-        v0: pyct.NDArray = None,  # warm start for variance
+        b1: pyct.Real = 0.9,
+        b2: pyct.Real = 0.999,
+        m0: pyct.NDArray = None,
+        v0: pyct.NDArray = None,
         stop_crit_sub: pyca.solver.StoppingCriterion = None,
         p: pyct.Real = 0.5,
         eps: pyct.Real = 1e-6,

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -286,7 +286,7 @@ class ProxAdam(pyca.Solver):
     def m_step(self):
         mst = self._mstate  # shorthand
 
-        x = mst["x"]
+        x, a = mst["x"], mst["a"]
         xp = pycu.get_array_module(x)
         gm = self._f.grad(x)
         gv = gm.copy()
@@ -317,10 +317,12 @@ class ProxAdam(pyca.Solver):
         ## =====================================================
 
         ## Part 2: setup + eval PGD sub-problems ===============
-        a = mst["a"]
-        x = x - a * (phi / psi)
-
-        xp = pycu.get_array_module(x)
+        # In-place implementation of -----------------
+        #   x = x - a * (phi / psi)
+        phi /= psi
+        phi *= a
+        x -= phi
+        # --------------------------------------------
         gamma = pycrt.coerce(a / xp.max(psi))
 
         sqrt_psi = xp.sqrt(psi)

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -13,7 +13,7 @@ __all__ = [
 
 class ProxAdam(pyca.Solver):
     r"""
-    Proximal Adam solver.
+    Proximal Adam solver [ProxAdam]_.
 
     ProxAdam minimizes
 
@@ -28,21 +28,32 @@ class ProxAdam(pyca.Solver):
     * :math:`\mathcal{G}:\mathbb{R}^N\rightarrow \mathbb{R}\cup\{+\infty\}` is a *proper*, *lower
       semicontinuous* and *convex function* with a *simple proximal operator*.
 
-    It does so by estimating the mean and the variance of :math:`\mathbf{g}_t=\nabla\mathcal{F}` at each
-    iteration by :math:`\phi_t=\phi(\mathbf{g}_1, \ldots, \mathbf{g}_t)` and
-    :math:`\psi_t=\psi(\mathbf{g}_1^2, \ldots, \mathbf{g}_t^2)` respectively first, then solving the proximal
-    sub-problem:
+    ProxAdam is a suitable alternative to Proximal Gradient Descent
+    (:py:class:`~pycsou.opt.solvel.pgd.PGD`) when:
 
-    ..math::
+    * computing :math:`\beta` to optimally choose the step size is infeasible, and
+    * line-search methods to estimate step sizes are too expensive.
 
-       {\min_{\mathbf{z}\in\mathbb{R}^N} \;\mathcal{G}(\mathbf{z})\;\;+\;\;\frac{1}{2\alpha}||\mathbf{z}-\mathbf{x}_t||_H^2},
+    Compared to PGD, ProxAdam:
 
-    where :math:`H=\text{diag}(\psi_t)`, which can be solved through Proximal Gradient Descent.
-    Three variants of this algorithm are implemented, corresponding to three distinct :math:`\phi` and :math:`psi` pairs:
+    * auto-tunes gradient updates based on stochastic estimates of
+      :math:`\phi_{t} = \mathbb{E}[\nabla\mathcal{F}]` and :math:`\psi_{t} =
+      \mathbb{E}[\nabla\mathcal{F}^{2}]` respectively;
+    * uses a modified proximity operator at each iteration to update coordinates at varying scales:
+
+    .. math::
+
+       \text{prox}_{\alpha\mathcal{G}}(\mathbf{x}_{t})
+       =
+       \min_{\mathbf{z}\in\mathbb{R}^N} \;\mathcal{G}(\mathbf{z})\;\;+\;\;\frac{1}{2\alpha}||\mathbf{z}-\mathbf{x}_t||_H^2,
+
+    where :math:`H=\text{diag}(\psi_t)`.
+    The modified proximity operator is computed by solving a PGD sub-problem.
+    ProxAdam has many named variants for particular choices of :math:`\phi` and :math:`\psi`:
 
     * Adam:
 
-    ..math::
+    .. math::
 
        \phi_t
        =
@@ -50,7 +61,8 @@ class ProxAdam(pyca.Solver):
          \mathbf{m}_t
        }{
          1-\beta_1^t
-       } \\
+       }
+       \qquad
        \psi_t
        =
        \sqrt{
@@ -63,21 +75,23 @@ class ProxAdam(pyca.Solver):
 
     * AMSGrad:
 
-    ..math::
+    .. math::
 
-       \phi_t = \mathbf{m}_t \\
+       \phi_t = \mathbf{m}_t
+       \qquad
        \psi_t = \sqrt{\hat{\mathbf{v}}_t}
 
     * PAdam:
 
-    ..math::
+    .. math::
 
-       \phi_t = \mathbf{m}_t \\
-       \psi_t = \hat{\mathbf{v}}_t^p
+       \phi_t = \mathbf{m}_t
+       \qquad
+       \psi_t = \hat{\mathbf{v}}_t^p,
 
     where in all cases:
 
-    ..math::
+    .. math::
 
        \mathbf{m}_t
        =
@@ -91,22 +105,20 @@ class ProxAdam(pyca.Solver):
        (1-\beta_2)\mathbf{g}_t^2\\
        \hat{\mathbf{v}}_t
        =
-       \max(\hat{\mathbf{v}}_{t-1}, \mathbf{v}_t)
+       \max(\hat{\mathbf{v}}_{t-1}, \mathbf{v}_t),
 
     with :math:`\mathbf{m}_0 = \mathbf{v}_0 = \mathbf{0}`.
 
-    Further details in [ProxAdam]_.
-
     **Remark 1:**
-    The algorithm is still valid if :math:`\mathcal{G}` is zero. It is not if :math:`\mathcal{F}` is zero.
+    The algorithm is still valid if :math:`\mathcal{G}` is zero.
 
     **Remark 2:**
     The convergence is guaranteed for step sizes :math:`\alpha\leq 2/\beta`.
 
     **Remark 3:**
     The relative norm change of the primal variable is used as the default stopping criterion.
-    By default, the algorithm stops when the norm of the difference between two consecutive
-    iterates :math:`\{\mathbf{x}_n\}_{n\in\mathbb{N}}` is smaller than 1e-4.
+    By default, the algorithm stops when the norm of the difference between two consecutive iterates
+    :math:`\{\mathbf{x}_n\}_{n\in\mathbb{N}}` is smaller than 1e-4.
     Different stopping criteria can be used. (see :py:mod:`~pycsou.opt.solver.stop`.)
     By default, the same stopping criterion is used for the proximal sub-problem.
 
@@ -114,56 +126,61 @@ class ProxAdam(pyca.Solver):
 
     x0: pyct.NDArray
         (..., N) initial point(s).
-    variant: str
+    variant: "adam", "amsgrad", "padam"
         Name of the ProxAdam variant to use.
-        Use "adam" for Adam. (default)
-        Use "amsgrad" for AMSGrad.
-        Use "padam" for PAdam.
+        Defaults to "adam"
     a: pyct.Real
-        Gradient step size.
+        Max normalized gradient step size.
         Defaults to :math:`1 / \beta` if unspecified.
     b1: pyct.Real
-        Factor for mean gradient computation.
+        1st-order gradient exponential decay :math:`\beta_{1} \in [0, 1)`.
     b2: pyct.Real
-        Factor for gradient variance computation.
+        2nd-order gradient exponential decay :math:`\beta_{2} \in [0, 1)`.
     m0: pyct.NDArray
-        (..., N) first mean estimate of the gradient corresponding to
-        each initial point, defaults to the zero vector.
+        (..., N) initial 1st-order gradient estimate corresponding to each initial point.
+        Defaults to the null vector if unspecified.
     v0: pyct.NDArray
-        (..., N) first variance estimate of the gradient corresponding to
-        each initial point, defaults to the zero vector.
+        (..., N) initial 2nd-order gradient estimate corresponding to each initial point.
+        Defaults to the null vector if unspecified.
     stop_crit_sub: pyca.solver.StoppingCriterion
-        Sub-problem stopping criterion, defaults to the main problem's.
+        Sub-problem stopping criterion.
+        Default: use same stopping criterion as main problem.
     **kwargs
         p: pyct.Real
-            Power used in the variance estimate. Must be specified for PAdam, unused else. Should be between 0 and 0.5.
+            PAdam power parameter :math:`p \in [0, 0.5]`.
+            Must be specified for PAdam, unused otherwise.
         eps_adam: pyct.Real
-            Noise term used exclusively in Adam, unused else. Defaults to 1e-6.
+            Adam noise parameter :math:`\epsilon`.
+            This term is used exclusively if `variant="adam"`.
+            Defaults to 1e-6.
 
     Example
     --------
-    Consider the following optimisation problem:
+    Consider the following optimization problem:
 
-    ..math:
+    .. math::
 
        \min_{\mathbf{x}\in\mathbb{R}^N} \Vert{\mathbf{x}-\mathbf{1}}\Vert_2^2 + \Vert{\mathbf{x}-\mathbf{1}}\Vert_1
-    
-    >>> import numpy as np
 
-    >>> from pycsou.operator import shift_loss
-    >>> from pycsou.operator.func import L2Norm, SquaredL2Norm
-    >>> from pycsou.opt.solver import ProxAdam
+    .. code-block:: python3
 
-    >>> N = 3
-    >>> f = SquaredL2Norm(dim=N).asloss(np.ones((N,)))
-    >>> g = L2Norm(dim=N).asloss(np.ones((N,)))
+       import numpy as np
 
-    >>> prox_adam = ProxAdam(f, g)
-    >>> x0 = np.zeros((N,))
-    >>> prox_adam.fit(x0=x0, variant="padam", p=0.25)
-    >>> x_star = prox_adam.solution()
-    >>> assert np.allclose(x_star, np.ones((N,)))
+       from pycsou.operator.func import L1Norm, SquaredL2Norm
+       from pycsou.opt.solver import ProxAdam
 
+       N = 3
+       f = SquaredL2Norm(dim=N).asloss(1)
+       g = L1Norm(dim=N).asloss(1)
+
+       prox_adam = ProxAdam(f, g)
+       prox_adam.fit(
+           x0=np.zeros((N,)),
+           variant="padam",
+           p=0.25,
+       )
+       x_opt = prox_adam.solution()
+       np.allclose(x_opt, 1)  # True
     """
     __eps_adam_default = 1e-6
 

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -359,9 +359,7 @@ class ProxAdam(pyca.Solver):
             h_half = pycl.DiagonalOp(xp.sqrt(_psi))
 
             f1 = pycof.SquaredL2Norm().asloss(h_half.apply(_x)) * h_half
-            f2 = (pycof.SquaredL2Norm() * h_half).asloss(_x)
-            f = f1 * scale  # gives correct results
-            # f = f2 * scale  # gives wrong results
+            f = f1 * scale
 
             kwargs = mst["subproblem_init_kwargs"].copy()
             kwargs.update(show_progress=False)

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -316,7 +316,7 @@ class ProxAdam(pyca.Solver):
         psi = self.__psi(t=self._astate["idx"])
         ## =====================================================
 
-
+        ## Part 2: setup + eval PGD sub-problems ===============
         a = mst["a"]
         x = x - a * (phi / psi)
 
@@ -328,6 +328,7 @@ class ProxAdam(pyca.Solver):
         pgd_sub = pycos.PGD(h, self._g, show_progress=False)
         pgd_sub.fit(x0=x.ravel(), tau=gamma, stop_crit=mst["subproblem_stop_crit"])
         x = pgd_sub.solution().reshape(x.shape)
+        ## =====================================================
 
         mst["x"] = x
 

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -119,11 +119,13 @@ class ProxAdam(pyca.Solver):
     The convergence is guaranteed for step sizes :math:`\alpha\leq 2/\beta`.
 
     **Remark 3:**
-    The relative norm change of the primal variable is used as the default stopping criterion.
+    The default stopping criterion (after 50 iterations) is the relative norm change of the primal
+    variable.
     By default, the algorithm stops when the norm of the difference between two consecutive iterates
     :math:`\{\mathbf{x}_n\}_{n\in\mathbb{N}}` is smaller than 1e-4.
     Different stopping criteria can be used. (see :py:mod:`~pycsou.opt.solver.stop`.)
     By default, the same stopping criterion is used for the proximal sub-problem.
+    (A minimum number of iterations is enforced to avoid premature stopping on slow starts.)
 
     ``ProxAdam.fit()`` **Parameterization**
 
@@ -385,18 +387,19 @@ class ProxAdam(pyca.Solver):
         mst["x"] = x
 
     def default_stop_crit(self) -> pyca.StoppingCriterion:
-        from pycsou.opt.stop import RelError
+        from pycsou.opt.stop import MaxIter, RelError
 
         # Described in [ProxAdam]_ and used in their implementation:
         # https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.py
-        stop_crit = RelError(
+        rel_error = RelError(
             eps=1e-4,
             var="x",
             f=None,
             norm=2,
             satisfy_all=True,
         )
-        return stop_crit
+        min_steps = MaxIter(n=50)
+        return min_steps & rel_error
 
     def objective_func(self) -> pyct.NDArray:
         func = lambda x: self._f.apply(x) + self._g.apply(x)

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -328,7 +328,8 @@ class ProxAdam(pyca.Solver):
     def default_stop_crit(self) -> pyca.StoppingCriterion:
         from pycsou.opt.stop import RelError
 
-        # Used in https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.py as well as corresp. paper
+        # Described in [ProxAdam]_ and used in their implementation:
+        # https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.py
         stop_crit = RelError(
             eps=1e-4,
             var="x",

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -1,6 +1,9 @@
 import warnings
 
 import pycsou.abc as pyca
+import pycsou.operator.func as pycof
+import pycsou.operator.linop as pycl
+import pycsou.opt.solver as pycos
 import pycsou.runtime as pycrt
 import pycsou.util as pycu
 import pycsou.util.ptype as pyct
@@ -281,10 +284,6 @@ class ProxAdam(pyca.Solver):
         mst["b2"] = b2
 
     def m_step(self):
-        from pycsou.operator import SquaredL2Norm
-        from pycsou.operator.linop import DiagonalOp
-        from pycsou.opt.solver import PGD
-
         mst = self._mstate  # shorthand
         x, m, v = mst["x"], mst["mean"], mst["variance"]
 
@@ -318,8 +317,8 @@ class ProxAdam(pyca.Solver):
         gamma = pycrt.coerce(a / xp.max(psi))
 
         sqrt_psi = xp.sqrt(psi)
-        h = (0.5 / a) * SquaredL2Norm().asloss((sqrt_psi * x).ravel()) * DiagonalOp(sqrt_psi.ravel())
-        pgd_sub = PGD(h, self._g, show_progress=False)
+        h = (0.5 / a) * pycof.SquaredL2Norm().asloss((sqrt_psi * x).ravel()) * pycl.DiagonalOp(sqrt_psi.ravel())
+        pgd_sub = pycos.PGD(h, self._g, show_progress=False)
         pgd_sub.fit(x0=x.ravel(), tau=gamma, stop_crit=mst["subproblem_stop_crit"])
         x = pgd_sub.solution().reshape(x.shape)
 

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -356,6 +356,7 @@ class ProxAdam(pyca.Solver):
         x_sub = []  # sub-problem solutions
         scale = pycrt.coerce(0.5 / a)
         for _x, _psi in zip(x.reshape(-1, N), psi.reshape(-1, N)):
+            gamma = pycrt.coerce(a / xp.max(_psi))
             h_half = pycl.DiagonalOp(xp.sqrt(_psi))
 
             f1 = pycof.SquaredL2Norm().asloss(h_half.apply(_x)) * h_half
@@ -367,6 +368,7 @@ class ProxAdam(pyca.Solver):
 
             slvr.fit(
                 x0=_x,
+                tau=gamma,
                 stop_crit=mst["subproblem_stop_crit"],
             )
             x_sub.append(slvr.solution())

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -1,0 +1,366 @@
+import warnings
+
+import pycsou.abc as pyca
+import pycsou.runtime as pycrt
+import pycsou.util as pycu
+import pycsou.util.ptype as pyct
+import pycsou.util.warning as pycuw
+
+__all__ = [
+    "ProxAdam",
+]
+
+
+class ProxAdam(pyca.Solver):
+    r"""
+    Proximal Adam solver.
+
+    ProxAdam minimizes
+
+    .. math::
+
+       {\min_{\mathbf{x}\in\mathbb{R}^N} \;\mathcal{F}(\mathbf{x})\;\;+\;\;\mathcal{G}(\mathbf{x})},
+
+    where:
+
+    * :math:`\mathcal{F}:\mathbb{R}^N\rightarrow \mathbb{R}` is *convex* and *differentiable*, with
+      :math:`\beta`-*Lipschitz continuous* gradient, for some :math:`\beta\in[0,+\infty[`.
+    * :math:`\mathcal{G}:\mathbb{R}^N\rightarrow \mathbb{R}\cup\{+\infty\}` is a *proper*, *lower
+      semicontinuous* and *convex function* with a *simple proximal operator*.
+
+    It does so by estimating the mean and the variance of :math:`\mathbf{g}_t=\nabla\mathcal{F}` at each
+    iteration by :math:`\phi_t=\phi(\mathbf{g}_1, \ldots, \mathbf{g}_t)` and
+    :math:`\psi_t=\psi(\mathbf{g}_1^2, \ldots, \mathbf{g}_t^2)` respectively first, then solving the proximal
+    sub-problem:
+
+    ..math::
+
+       {\min_{\mathbf{z}\in\mathbb{R}^N} \;\mathcal{G}(\mathbf{z})\;\;+\;\;\frac{1}{2\alpha}||\mathbf{z}-\mathbf{x}_t||_H^2},
+
+    where :math:`H=\text{diag}(\psi_t)`, which can be solved through Proximal Gradient Descent.
+    Three variants of this algorithm are implemented, corresponding to three distinct :math:`\phi` and :math:`psi` pairs:
+
+    * Adam:
+
+    ..math::
+
+       \phi_t
+       =
+       \frac{
+         \mathbf{m}_t
+       }{
+         1-\beta_1^t
+       } \\
+       \psi_t
+       =
+       \sqrt{
+         \frac{
+           \mathbf{v}_t
+         }{
+           1-\beta_2^t
+         }
+       } + \epsilon
+
+    * AMSGrad:
+
+    ..math::
+
+       \phi_t = \mathbf{m}_t \\
+       \psi_t = \sqrt{\hat{\mathbf{v}}_t}
+
+    * PAdam:
+
+    ..math::
+
+       \phi_t = \mathbf{m}_t \\
+       \psi_t = \hat{\mathbf{v}}_t^p
+
+    where in all cases:
+
+    ..math::
+
+       \mathbf{m}_t
+       =
+       \beta_1\mathbf{m}_{t-1}
+       +
+       (1-\beta_1)\mathbf{g}_t \\
+       \mathbf{v}_t
+       =
+       \beta_2\mathbf{v}_{t-1}
+       +
+       (1-\beta_2)\mathbf{g}_t^2\\
+       \hat{\mathbf{v}}_t
+       =
+       \max(\hat{\mathbf{v}}_{t-1}, \mathbf{v}_t)
+
+    with :math:`\mathbf{m}_0 = \mathbf{v}_0 = \mathbf{0}`.
+
+    Further details in [ProxAdam]_.
+
+    **Remark 1:**
+    The algorithm is still valid if :math:`\mathcal{G}` is zero. It is not if :math:`\mathcal{F}` is zero.
+
+    **Remark 2:**
+    The convergence is guaranteed for step sizes :math:`\alpha\leq 2/\beta`.
+
+    **Remark 3:**
+    The relative norm change of the primal variable is used as the default stopping criterion.
+    By default, the algorithm stops when the norm of the difference between two consecutive
+    iterates :math:`\{\mathbf{x}_n\}_{n\in\mathbb{N}}` is smaller than 1e-4.
+    Different stopping criteria can be used. (see :py:mod:`~pycsou.opt.solver.stop`.)
+    By default, the same stopping criterion is used for the proximal sub-problem.
+
+    ``ProxAdam.fit()`` **Parameterization**
+
+    x0: pyct.NDArray
+        (..., N) initial point(s).
+    variant: str
+        Name of the ProxAdam variant to use.
+        Use "adam" for Adam. (default)
+        Use "amsgrad" for AMSGrad.
+        Use "padam" for PAdam.
+    a: pyct.Real
+        Gradient step size.
+        Defaults to :math:`1 / \beta` if unspecified.
+    b1: pyct.Real
+        Factor for mean gradient computation.
+    b2: pyct.Real
+        Factor for gradient variance computation.
+    m0: pyct.NDArray
+        (..., N) first mean estimate of the gradient corresponding to
+        each initial point, defaults to the zero vector.
+    v0: pyct.NDArray
+        (..., N) first variance estimate of the gradient corresponding to
+        each initial point, defaults to the zero vector.
+    stop_crit_sub: pyca.solver.StoppingCriterion
+        Sub-problem stopping criterion, defaults to the main problem's.
+    **kwargs
+        p: pyct.Real
+            Power used in the variance estimate. Must be specified for PAdam, unused else. Should be between 0 and 0.5.
+        eps_adam: pyct.Real
+            Noise term used exclusively in Adam, unused else. Defaults to 1e-6.
+
+    Example
+    --------
+    Consider the following optimisation problem:
+
+    ..math:
+
+       \min_{\mathbf{x}\in\mathbb{R}^N} \Vert{\mathbf{x}-\mathbf{1}}\Vert_2^2 + \Vert{\mathbf{x}-\mathbf{1}}\Vert_1
+    
+    >>> import numpy as np
+
+    >>> from pycsou.operator import shift_loss
+    >>> from pycsou.operator.func import L2Norm, SquaredL2Norm
+    >>> from pycsou.opt.solver import ProxAdam
+
+    >>> N = 3
+    >>> f = SquaredL2Norm(dim=N).asloss(np.ones((N,)))
+    >>> g = L2Norm(dim=N).asloss(np.ones((N,)))
+
+    >>> prox_adam = ProxAdam(f, g)
+    >>> x0 = np.zeros((N,))
+    >>> prox_adam.fit(x0=x0, variant="padam", p=0.25)
+    >>> x_star = prox_adam.solution()
+    >>> assert np.allclose(x_star, np.ones((N,)))
+
+    """
+    __eps_adam_default = 1e-6
+
+    def __init__(self, f: pyca.DiffFunc, g: pyca.ProxFunc, **kwargs):
+        kwargs.update(
+            log_var=kwargs.get("log_var", ("x",)),
+        )
+        super().__init__(**kwargs)
+
+        self._f = f
+        self._g = g
+
+    @pycrt.enforce_precision(i=("x0", "a", "b1", "b2", "m0", "v0"))
+    def m_init(
+        self,
+        x0: pyct.NDArray,
+        variant: str = "adam",
+        a: pyct.Real = None,
+        b1: pyct.Real = 0.9,  # default values from:
+        b2: pyct.Real = 0.999,  # https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.
+        m0: pyct.NDArray = None,  # warm start for mean
+        v0: pyct.NDArray = None,  # warm start for variance
+        stop_crit_sub: pyca.solver.StoppingCriterion = None,  # sub-problem stopping criterion
+        **kwargs,  # p for padam, eps_adam for adam with eps_adam defaulting to some value > 0
+    ):
+        mst = self._mstate  # shorthand
+
+        mst["x"] = x0
+
+        if a is None:
+            try:
+                mst["a"] = pycrt.coerce(1 / self._f.diff_lipschitz())
+            except ZeroDivisionError as exc:
+                # _f is constant-valued: a is a free parameter.
+                mst["a"] = 1.0
+                msg = "\n".join(
+                    [
+                        rf"[ProxAdam] The gradient/proximal step size a is auto-set to {mst['a']}.",
+                        r"           Choosing a manually may lead to faster convergence.",
+                    ]
+                )
+                warnings.warn(msg, pycuw.AutoInferenceWarning)
+        else:
+            try:
+                assert a > 0
+                mst["a"] = a
+            except:
+                raise ValueError(f"[ProxAdam] a must be positive, got {a}.")
+
+        mst["variant"] = self.__parse_variant(variant)
+
+        if mst["variant"] == "padam":
+            if (p := kwargs.get("p")) is None:
+                raise ValueError("[ProxAdam] To use PAdam, specify the power p as a kwarg in ProxAdam.fit()")
+            else:
+                mst["padam_p"] = p
+
+        if mst["variant"] == "adam":
+            eps_adam = kwargs.get("eps_adam")
+            mst["eps_adam"] = self.__eps_adam_default if eps_adam is None else eps_adam
+
+        xp = pycu.get_array_module(x0)
+
+        if m0 is not None:
+            assert m0.shape == x0.shape
+            mst["mean"] = m0
+        else:
+            mst["mean"] = xp.full(shape=x0.shape, fill_value=0.0, dtype=x0.dtype)
+
+        if v0 is not None:
+            assert v0.shape == x0.shape
+            mst["variance"] = v0
+        else:
+            mst["variance"] = xp.full(shape=x0.shape, fill_value=0.0, dtype=x0.dtype)
+
+        if stop_crit_sub is None:
+            stop_crit_sub = self.default_stop_crit()
+
+        mst["subproblem_stop_crit"] = stop_crit_sub
+
+        mst["b1"] = b1
+        mst["b2"] = b2
+
+        mst["variance_hat"] = mst["variance"]
+
+        mst["phi"] = self.__compute__phi(1)
+        mst["psi"] = self.__compute__psi(1)
+
+    def m_step(self):
+        from pycsou.operator import SquaredL2Norm
+        from pycsou.operator.linop import DiagonalOp
+        from pycsou.opt.solver import PGD
+
+        class __FlattenedProxFunc(pyca.ProxFunc):
+            def __init__(self, r: pyca.ProxFunc, dim: pyct.Integer):
+                super().__init__((1, dim))
+                self.__inner = r
+
+            def prox(self, arr: pyct.NDArray, tau: pyct.Real) -> pyct.NDArray:
+                return self.__inner.prox(arr, tau).ravel()
+
+            def asloss(self, data: pyct.NDArray = None) -> pyct.OpT:
+                return self.__inner.asloss(data)
+
+            def apply(self, arr: pyct.NDArray) -> pyct.NDArray:
+                return self.__inner.apply(arr).ravel()
+
+        mst = self._mstate  # shorthand
+        x, m, v = mst["x"], mst["mean"], mst["variance"]
+
+        g = self._f.grad(x)
+
+        b1 = mst["b1"]
+        # In-place implementation of -----------------
+        #   m = b1 * m + (1 - b1) * g
+        m = b1 * m
+        m += (1 - b1) * g
+        # --------------------------------------------
+
+        b2 = mst["b2"]
+        # In-place implementation of -----------------
+        #   v = b2 * v + (1 - b2) * (g ** 2)
+        v = b2 * v
+        v += (1 - b2) * (g**2)
+        # --------------------------------------------
+
+        mst["mean"], mst["variance"] = m, v
+        xp = pycu.get_array_module(x)
+        mst["variance_hat"] = xp.maximum(mst["variance_hat"], v)
+
+        phi = self.__compute__phi(self._astate["idx"])
+        psi = self.__compute__psi(self._astate["idx"])
+
+        a = mst["a"]
+        x = x - a * (phi / psi)
+
+        xp = pycu.get_array_module(x)
+        gamma = pycrt.coerce(a / xp.max(psi))
+
+        sqrt_psi = xp.sqrt(psi)
+        h = (0.5 / a) * SquaredL2Norm().asloss((sqrt_psi * x).ravel()) * DiagonalOp(sqrt_psi.ravel())
+        pgd_sub = PGD(h, __FlattenedProxFunc(self._g, x.size), show_progress=False)
+        pgd_sub.fit(x0=x.ravel(), tau=gamma, stop_crit=mst["subproblem_stop_crit"])
+        x = pgd_sub.solution().reshape(x.shape)
+
+        mst["x"], mst["phi"], mst["psi"] = x, phi, psi
+
+    def default_stop_crit(self) -> pyca.StoppingCriterion:
+        from pycsou.opt.stop import RelError
+
+        # Used in https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.py as well as corresp. paper
+        stop_crit = RelError(
+            eps=1e-4,
+            var="x",
+            f=None,
+            norm=2,
+            satisfy_all=True,
+        )
+        return stop_crit
+
+    def objective_func(self) -> pyct.NDArray:
+        func = lambda x: self._f.apply(x) + self._g.apply(x)
+        y = func(self._mstate["x"])
+        return y
+
+    def solution(self) -> pyct.NDArray:
+        """
+        Returns
+        -------
+        x: pyct.NDArray
+            (..., N) solution.
+        """
+        data, _ = self.stats()
+        return data.get("x")
+
+    def __compute__phi(self, t):
+        mst = self._mstate
+        v = mst["variant"]
+        m = mst["mean"]
+        if v == "adam":
+            return m / (1 - (mst["b1"] ** t))
+        elif v in ["amsgrad", "padam"]:
+            return m
+
+    def __compute__psi(self, t):
+        mst = self._mstate
+        xp = pycu.get_array_module(mst["x"])
+        v = mst["variant"]
+        if v == "adam":
+            return xp.sqrt(mst["variance"] / (1 - (mst["b2"] ** t))) + mst["eps_adam"]
+        elif v == "amsgrad":
+            return xp.sqrt(mst["variance_hat"])
+        elif v == "padam":
+            return mst["variance_hat"] ** mst["padam_p"]
+
+    def __parse_variant(self, variant: str) -> str:
+        supported_variants = {"adam", "amsgrad", "padam"}
+        if (v := variant.lower().strip()) not in supported_variants:
+            raise ValueError(f"Unsupported variant '{variant}'.")
+        return v

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -354,8 +354,8 @@ class ProxAdam(pyca.Solver):
         # In light of the above, we opt for Option 2.
         *x_sh, N = x.shape
         x_sub = []  # sub-problem solutions
+        scale = pycrt.coerce(0.5 / a)
         for _x, _psi in zip(x.reshape(-1, N), psi.reshape(-1, N)):
-            scale = pycrt.coerce(0.5 / a)
             h_half = pycl.DiagonalOp(xp.sqrt(_psi))
 
             f1 = pycof.SquaredL2Norm().asloss(h_half.apply(_x)) * h_half

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -257,20 +257,6 @@ class ProxAdam(pyca.Solver):
         from pycsou.operator.linop import DiagonalOp
         from pycsou.opt.solver import PGD
 
-        class __FlattenedProxFunc(pyca.ProxFunc):
-            def __init__(self, r: pyca.ProxFunc, dim: pyct.Integer):
-                super().__init__((1, dim))
-                self.__inner = r
-
-            def prox(self, arr: pyct.NDArray, tau: pyct.Real) -> pyct.NDArray:
-                return self.__inner.prox(arr, tau).ravel()
-
-            def asloss(self, data: pyct.NDArray = None) -> pyct.OpT:
-                return self.__inner.asloss(data)
-
-            def apply(self, arr: pyct.NDArray) -> pyct.NDArray:
-                return self.__inner.apply(arr).ravel()
-
         mst = self._mstate  # shorthand
         x, m, v = mst["x"], mst["mean"], mst["variance"]
 
@@ -305,7 +291,7 @@ class ProxAdam(pyca.Solver):
 
         sqrt_psi = xp.sqrt(psi)
         h = (0.5 / a) * SquaredL2Norm().asloss((sqrt_psi * x).ravel()) * DiagonalOp(sqrt_psi.ravel())
-        pgd_sub = PGD(h, __FlattenedProxFunc(self._g, x.size), show_progress=False)
+        pgd_sub = PGD(h, self._g, show_progress=False)
         pgd_sub.fit(x0=x.ravel(), tau=gamma, stop_crit=mst["subproblem_stop_crit"])
         x = pgd_sub.solution().reshape(x.shape)
 

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -216,7 +216,6 @@ class ProxAdam(pyca.Solver):
         eps: pyct.Real = 1e-6,
     ):
         mst = self._mstate  # shorthand
-
         mst["x"] = x0
 
         if self._g is None:
@@ -273,7 +272,6 @@ class ProxAdam(pyca.Solver):
 
         if stop_crit_sub is None:
             stop_crit_sub = self.default_stop_crit()
-
         mst["subproblem_stop_crit"] = stop_crit_sub
 
         assert 0 <= b1 < 1, f"b1: expected value in [0, 1), got {b1}."
@@ -281,11 +279,6 @@ class ProxAdam(pyca.Solver):
 
         assert 0 <= b2 < 1, f"b2: expected value in [0, 1), got {b2}."
         mst["b2"] = b2
-
-        mst["variance_hat"] = mst["variance"]
-
-        mst["phi"] = self.__compute__phi(1)
-        mst["psi"] = self.__compute__psi(1)
 
     def m_step(self):
         from pycsou.operator import SquaredL2Norm
@@ -330,7 +323,7 @@ class ProxAdam(pyca.Solver):
         pgd_sub.fit(x0=x.ravel(), tau=gamma, stop_crit=mst["subproblem_stop_crit"])
         x = pgd_sub.solution().reshape(x.shape)
 
-        mst["x"], mst["phi"], mst["psi"] = x, phi, psi
+        mst["x"] = x
 
     def default_stop_crit(self) -> pyca.StoppingCriterion:
         from pycsou.opt.stop import RelError

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -119,13 +119,12 @@ class ProxAdam(pyca.Solver):
     The convergence is guaranteed for step sizes :math:`\alpha\leq 2/\beta`.
 
     **Remark 3:**
-    The default stopping criterion (after 50 iterations) is the relative norm change of the primal
-    variable.
+    The default stopping criterion is the relative norm change of the primal variable.
     By default, the algorithm stops when the norm of the difference between two consecutive iterates
     :math:`\{\mathbf{x}_n\}_{n\in\mathbb{N}}` is smaller than 1e-4.
-    Different stopping criteria can be used. (see :py:mod:`~pycsou.opt.solver.stop`.)
+    Different stopping criteria can be used. (see :py:mod:`~pycsou.opt.solver.stop`.) It is recommended
+    to change the stopping criterion when using the PAdam and AMSGrad variants to avoid premature stops.
     By default, the same stopping criterion is used for the proximal sub-problem.
-    (A minimum number of iterations is enforced to avoid premature stopping on slow starts.)
 
     ``ProxAdam.fit()`` **Parameterization**
 

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -357,7 +357,11 @@ class ProxAdam(pyca.Solver):
         for _x, _psi in zip(x.reshape(-1, N), psi.reshape(-1, N)):
             scale = pycrt.coerce(0.5 / a)
             h_half = pycl.DiagonalOp(xp.sqrt(_psi))
-            f = ((scale * pycof.SquaredL2Norm()) * h_half).asloss(_x)
+
+            f1 = pycof.SquaredL2Norm().asloss(h_half.apply(_x)) * h_half
+            f2 = (pycof.SquaredL2Norm() * h_half).asloss(_x)
+            f = f1 * scale  # gives correct results
+            # f = f2 * scale  # gives wrong results
 
             kwargs = mst["subproblem_init_kwargs"].copy()
             kwargs.update(show_progress=False)

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -323,9 +323,8 @@ class ProxAdam(pyca.Solver):
         gv *= 1 - b2
         v += gv
         # --------------------------------------------
-        mst["variance"] = v
-        mst["variance_hat"] = xp.maximum(mst["variance_hat"], v)
-        mst["variance_hat"] = xp.maximum(mst["variance_hat"], mst["eps_variance"])  # avoid division by zero
+        mst["variance"] = v.clip(mst["eps_variance"], None)  # avoid division-by-zero
+        mst["variance_hat"] = xp.maximum(mst["variance_hat"], mst["variance"])
 
         phi = self.__phi(t=self._astate["idx"])
         psi = self.__psi(t=self._astate["idx"])

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -266,7 +266,10 @@ class ProxAdam(pyca.Solver):
 
         mst["subproblem_stop_crit"] = stop_crit_sub
 
+        assert 0 <= b1 < 1, f"b1: expected value in [0, 1), got {b1}."
         mst["b1"] = b1
+
+        assert 0 <= b2 < 1, f"b2: expected value in [0, 1), got {b2}."
         mst["b2"] = b2
 
         mst["variance_hat"] = mst["variance"]

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -153,6 +153,9 @@ class ProxAdam(pyca.Solver):
         This term is used exclusively if `variant="adam"`.
         Defaults to 1e-6.
 
+    **Remark 4:**
+    If provided, 'm0' and 'v0' must be broadcastable with 'x0'.
+
     Example
     --------
     Consider the following optimization problem:
@@ -239,17 +242,24 @@ class ProxAdam(pyca.Solver):
 
         xp = pycu.get_array_module(x0)
 
-        if m0 is not None:
-            assert m0.shape == x0.shape
+        if m0 is None:
+            mst["mean"] = xp.zeros_like(x0)
+        elif m0.shape == x0.shape:
+            # No broadcasting involved
             mst["mean"] = m0
         else:
-            mst["mean"] = xp.full(shape=x0.shape, fill_value=0.0, dtype=x0.dtype)
+            x0, m0 = xp.broadcast_arrays(x0, m0)
+            mst["mean"] = m0.copy()
 
-        if v0 is not None:
-            assert v0.shape == x0.shape
+        if v0 is None:
+            mst["variance"] = xp.zeros_like(x0)
+        elif v0.shape == x0.shape:
+            # No broadcasting involved
             mst["variance"] = v0
         else:
-            mst["variance"] = xp.full(shape=x0.shape, fill_value=0.0, dtype=x0.dtype)
+            x0, v0 = xp.broadcast_arrays(x0, v0)
+            mst["variance"] = v0.copy()
+        mst["variance_hat"] = mst["variance"]
 
         if stop_crit_sub is None:
             stop_crit_sub = self.default_stop_crit()

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -208,7 +208,7 @@ class ProxAdam(pyca.Solver):
         self._g = g
 
     @pycrt.enforce_precision(i=("x0", "a", "b1", "b2", "m0", "v0", "p", "eps"))
-    def m_init(  # default values from https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.
+    def m_init(  # default values from https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.py
         self,
         x0: pyct.NDArray,
         variant: str = "adam",

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -226,11 +226,11 @@ class ProxAdam(pyca.Solver):
                 mst["a"] = pycrt.coerce(1 / self._f.diff_lipschitz())
             except ZeroDivisionError as exc:
                 # _f is constant-valued: a is a free parameter.
-                mst["a"] = 1.0
+                mst["a"] = pycrt.coerce(1)
                 msg = "\n".join(
                     [
-                        rf"[ProxAdam] The gradient/proximal step size a is auto-set to {mst['a']}.",
-                        r"           Choosing a manually may lead to faster convergence.",
+                        rf"The gradient step size `a` is auto-set to {mst['a']}.",
+                        r"Choosing a manually may lead to faster convergence.",
                     ]
                 )
                 warnings.warn(msg, pycuw.AutoInferenceWarning)
@@ -239,7 +239,7 @@ class ProxAdam(pyca.Solver):
                 assert a > 0
                 mst["a"] = a
             except:
-                raise ValueError(f"[ProxAdam] a must be positive, got {a}.")
+                raise ValueError(f"`a` must be positive, got {a}.")
 
         mst["variant"] = self.__parse_variant(variant)
 

--- a/src/pycsou/opt/solver/prox_adam.py
+++ b/src/pycsou/opt/solver/prox_adam.py
@@ -387,7 +387,7 @@ class ProxAdam(pyca.Solver):
         mst["x"] = x
 
     def default_stop_crit(self) -> pyca.StoppingCriterion:
-        from pycsou.opt.stop import MaxIter, RelError
+        from pycsou.opt.stop import RelError
 
         # Described in [ProxAdam]_ and used in their implementation:
         # https://github.com/pmelchior/proxmin/blob/master/proxmin/algorithms.py
@@ -398,8 +398,7 @@ class ProxAdam(pyca.Solver):
             norm=2,
             satisfy_all=True,
         )
-        min_steps = MaxIter(n=50)
-        return min_steps & rel_error
+        return rel_error
 
     def objective_func(self) -> pyct.NDArray:
         func = lambda x: self._f.apply(x) + self._g.apply(x)

--- a/src/pycsou_tests/opt/solver/test_prox_adam.py
+++ b/src/pycsou_tests/opt/solver/test_prox_adam.py
@@ -1,0 +1,45 @@
+import itertools
+
+import numpy as np
+import pytest
+
+import pycsou.opt.solver as pycos
+import pycsou.util.ptype as pyct
+import pycsou_tests.opt.solver.conftest as conftest
+from pycsou.operator import shift_loss
+
+
+class TestProxAdam(conftest.SolverT):
+    @staticmethod
+    def spec_data(N: int) -> list[tuple[pyct.SolverC, dict, dict]]:
+        from pycsou.operator.func import L1Norm, SquaredL2Norm
+
+        klass = [
+            pycos.ProxAdam,
+        ]
+        kwargs_init = [
+            dict(f=shift_loss(SquaredL2Norm(dim=N), np.full((N,), 3.0)), g=L1Norm(dim=N)),
+        ]
+
+        kwargs_fit = []
+        param_sweep = dict(
+            x0=[
+                np.full((N,), 0.0),
+                np.full((1, N), 0.0),
+                np.full((3, 4, 2, N), 0.0),
+                np.full((2, N), 0.0),  # multiple initial points
+            ],
+            variant=["adam", "amsgrad", "padam"],
+            p=[0.25],
+        )
+        for config in itertools.product(*param_sweep.values()):
+            d = dict(zip(param_sweep.keys(), config))
+            kwargs_fit.append(d)
+
+        data = itertools.product(klass, kwargs_init, kwargs_fit)
+        return list(data)
+
+    @pytest.fixture(params=spec_data(N=7))
+    def spec(self, request) -> tuple[pyct.SolverC, dict, dict]:
+        klass, kwargs_init, kwargs_fit = request.param
+        return klass, kwargs_init, kwargs_fit

--- a/src/pycsou_tests/opt/solver/test_prox_adam.py
+++ b/src/pycsou_tests/opt/solver/test_prox_adam.py
@@ -18,16 +18,14 @@ class TestProxAdam(conftest.SolverT):
             pycos.ProxAdam,
         ]
         kwargs_init = [
-            dict(f=shift_loss(SquaredL2Norm(dim=N), np.full((N,), 3.0)), g=L1Norm(dim=N)),
+            dict(f=SquaredL2Norm(), g=L1Norm()),
         ]
 
         kwargs_fit = []
         param_sweep = dict(
             x0=[
-                np.full((N,), 0.0),
-                np.full((1, N), 0.0),
-                np.full((3, 4, 2, N), 0.0),
-                np.full((2, N), 0.0),  # multiple initial points
+                np.zeros((N,)),
+                np.zeros((3, 4, 2, N)),  # multiple initial points
             ],
             variant=["adam", "amsgrad", "padam"],
             p=[0.25],


### PR DESCRIPTION
Implementation in ```pycsou.opt.solver.prox_adam```. Reference paper: [Proximal Adam: Robust Adaptive Update Scheme for Constrained Optimization](https://arxiv.org/abs/1910.10094).

Three variants implemented: Adam, PAdam and AMSGrad.
Possible further developments: scheduling $\beta_1$ and $\beta_2$ moving averages coefficients.
