### PR TITLE
[BugFix][ChainRule][estimate_lipschitz] Small bugfix

### DIFF
--- a/src/pyxu/abc/arithmetic.py
+++ b/src/pyxu/abc/arithmetic.py
@@ -1198,8 +1198,10 @@ class ChainRule(Rule):
         else:
             L_lhs = self._lhs.estimate_lipschitz(**kwargs)
             L_rhs = self._rhs.estimate_lipschitz(**kwargs)
-
-        L = L_lhs * L_rhs
+        if L_lhs == 0 or L_rhs == 0:
+            L = 0.
+        else:
+            L = L_lhs * L_rhs
         return L
 
     @pxrt.enforce_precision(i=("arr", "tau"))


### PR DESCRIPTION
Motivation: if one of the operator has a 0-valued Lipschitz constant and the other is set to infinity (either it is actually infinity or it has not been computed yet), then the machine tries to multiply 0 and inf and raises a warning.

Solution: If one of the operators has a 0-valued Lipschitz constant, then it s possible to determine the value of the Lipschitz of the composed operators. Indeed, a 0-valued Lipschitz implies that the operator is itself constant, thus the composition of the operators is also constant, so that the output Lipschitz value is still 0. This commit implements this small change.