### PR TITLE
Structure tensor and cupy-stencil bug fixing

### DIFF
--- a/src/pyxu/operator/linop/filter.py
+++ b/src/pyxu/operator/linop/filter.py
@@ -999,6 +999,7 @@ class StructureTensor(pxa.DiffMap):
         self.grad = pxld.Gradient(
             dim_shape=dim_shape,
             directions=None,
+            diff_method=diff_method,
             mode=mode,
             gpu=gpu,
             dtype=dtype,

--- a/src/pyxu/operator/linop/stencil/_stencil.py
+++ b/src/pyxu/operator/linop/stencil/_stencil.py
@@ -302,7 +302,7 @@ class _Stencil_CP(_Stencil):
         with open(template_file, mode="r") as f:
             template = string.Template(f.read())
         code = template.substitute(
-            kernel_center=str(tuple(self._center)),
+            kernel_center=str(tuple(self._center.tolist())),
             kernel_width=str(self._kernel.shape),
             signature=signature,
             stencil_spec=self.__stencil_spec(),


### PR DESCRIPTION
Fix missing argument passing and stencil bug:

- Pass missing argument in structure tensor, diff_method argument was not passed to Gradient initialization, meaning that gaussian derivatives could not be used for structure tensor
- Solve numpy>=2 incompatibility in _Stencil_CP, to account for new representation of scalars in numpy >= 2.0